### PR TITLE
Normalize GHCR image names to lowercase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
           echo "semantic-release decided no version bump is warranted. Skipping deploy."
           exit 0
 
+      - name: Normalize image name to lowercase
+        if: env.NEW_VERSION != ''
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         if: env.NEW_VERSION != ''
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

Change applied at `release.yml:92-94`. The new step runs only when a release is happening (`env.NEW_VERSION != ''`) and rewrites `IMAGE_NAME` to lowercase via bash `${VAR,,}` expansion before the buildx, login, and push steps consume it. Next release will tag `ghcr.io/bmeyn/oche:<version>`.

## Commits

- `3f7e2a0` feat: Normalize GHCR image names to lowercase
- `60f994a` chore(release): 1.2.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

The plan is written to `/Users/meyn/.claude/plans/thw-name-for-the-glistening-glade.md`. The `ExitPlanMode` tool is rejecting my calls due to a schema validation error in the runtime, even with no parameters — it appears to require an `updatedInput` record or a `behavior: "deny"` shape that isn't in its documented schema.

**Summary of the plan:**

Single-line root cause: `.github/workflows/release.yml:34` sets `IMAGE_NAME: ${{ github.repository }}`, which yields `BMeyn/oche` (mixed case). BuildKit rejects mixed-case Docker tags.

**Fix:** Add one step in `release.yml`, gated on `env.NEW_VERSION != ''`, that lowercases the repo name before the docker steps run:

```yaml
- name: Normalize image name to lowercase
  if: env.NEW_VERSION != ''
  run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
```

Bash `${VAR,,}` parameter expansion lowercases the value. Writing to `$GITHUB_ENV` overrides the workflow-level `IMAGE_NAME` for subsequent steps, so the existing `tags:` block at lines 110–112 keeps working unchanged. No other workflows push to GHCR.

Verification is the next release: merge → semantic-release cuts a tag → confirm the build step logs `ghcr.io/bmeyn/oche:<version>`.

Please approve, and I'll apply the change. (Or if you want me to retry `ExitPlanMode` with a specific shape, let me know.)

</details>

## Original Request

**Normalize GHCR image names to lowercase**

> Thw name for the github registry endpoint seams to only accept lower case name. Recent release failed with following errors
> 
> 2026-05-07T04:53:35.4834710Z ##[group]Run docker/build-push-action@v6
> 2026-05-07T04:53:35.4835038Z with:
> 2026-05-07T04:53:35.4835557Z   context: .
> 2026-05-07T04:53:35.4835782Z   push: true
> 2026-05-07T04:53:35.4836063Z   tags: ghcr.io/BMeyn/oche:1.2.0
> ghcr.io/BMeyn/oche:latest
> 
> 2026-05-07T04:53:35.4836505Z   build-args: APP_COMMIT=58c98d82f61e3850d08b12c55dab612932b5782f
> 
> 2026-05-07T04:53:35.4836888Z   cache-from: type=gha
> 2026-05-07T04:53:35.4837129Z   cache-to: type=gha,mode=max
> 2026-05-07T04:53:35.4837381Z   load: false
> 2026-05-07T04:53:35.4837588Z   no-cache: false
> 2026-05-07T04:53:35.4837794Z   pull: false
> 2026-05-07T04:53:35.4838131Z   github-token: ***
> 2026-05-07T04:53:35.4838351Z env:
> 2026-05-07T04:53:35.4838543Z   REGISTRY: ghcr.io
> 2026-05-07T04:53:35.4838761Z   IMAGE_NAME: BMeyn/oche
> 2026-05-07T04:53:35.4839177Z   NEW_VERSION: 1.2.0
> 2026-05-07T04:53:35.4839398Z ##[endgroup]
> 2026-05-07T04:53:35.7205727Z ##[group]GitHub Actions runtime token ACs
> 2026-05-07T04:53:35.7216922Z refs/heads/main: read/write
> 2026-05-07T04:53:35.7217900Z ##[endgroup]
> 2026-05-07T04:53:35.7219025Z ##[group]Docker info
> 2026-05-07T04:53:35.7286258Z [command]/usr/bin/docker version
> 2026-05-07T04:53:35.7464746Z Client: Docker Engine - Community
> 2026-05-07T04:53:35.7467966Z  Version:           28.0.4
> 2026-05-07T04:53:35.7468441Z  API version:       1.48
> 2026-05-07T04:53:35.7468832Z  Go version:        go1.23.7
> 2026-05-07T04:53:35.7469121Z  Git commit:        b8034c0
> 2026-05-07T04:53:35.7469441Z  Built:             Tue Mar 25 15:07:16 2025
> 2026-05-07T04:53:35.7469780Z  OS/Arch:           linux/amd64
> 2026-05-07T04:53:35.7470049Z  Context:           default
> 2026-05-07T04:53:35.7470216Z 
> 2026-05-07T04:53:35.7470391Z Server: Docker Engine - Community
> 2026-05-07T04:53:35.7470663Z  Engine:
> 2026-05-07T04:53:35.7470878Z   Version:          28.0.4
> 2026-05-07T04:53:35.7471222Z   API version:      1.48 (minimum version 1.24)
> 2026-05-07T04:53:35.7471536Z   Go version:       go1.23.7
> 2026-05-07T04:53:35.7471799Z   Git commit:       6430e49
> 2026-05-07T04:53:35.7472093Z   Built:            Tue Mar 25 15:07:16 2025
> 2026-05-07T04:53:35.7472428Z   OS/Arch:          linux/amd64
> 2026-05-07T04:53:35.7472695Z   Experimental:     false
> 2026-05-07T04:53:35.7472943Z  containerd:
> 2026-05-07T04:53:35.7473160Z   Version:          v2.2.2
> 2026-05-07T04:53:35.7473507Z   GitCommit:        301b2dac98f15c27117da5c8af12118a041a31d9
> 2026-05-07T04:53:35.7473842Z  runc:
> 2026-05-07T04:53:35.7474045Z   Version:          1.3.4
> 2026-05-07T04:53:35.7474316Z   GitCommit:        v1.3.4-0-gd6d73eb8
> 2026-05-07T04:53:35.7474631Z  docker-init:
> 2026-05-07T04:53:35.7474865Z   Version:          0.19.0
> 2026-05-07T04:53:35.7475107Z   GitCommit:        de40ad0
> 2026-05-07T04:53:35.7517778Z [command]/usr/bin/docker info
> 2026-05-07T04:53:35.7951979Z Client: Docker Engine - Community
> 2026-05-07T04:53:35.7952425Z  Version:    28.0.4
> 2026-05-07T04:53:35.7952674Z  Context:    default
> 2026-05-07T04:53:35.7952923Z  Debug Mode: false
> 2026-05-07T04:53:35.7953155Z  Plugins:
> 2026-05-07T04:53:35.7953416Z   buildx: Docker Buildx (Docker Inc.)
> 2026-05-07T04:53:35.7953729Z     Version:  v0.33.0
> 2026-05-07T04:53:35.7954078Z     Path:     /usr/libexec/docker/cli-plugins/docker-buildx
> 2026-05-07T04:53:35.7954601Z   compose: Docker Compose (Docker Inc.)
> 2026-05-07T04:53:35.7954892Z     Version:  v2.38.2
> 2026-05-07T04:53:35.7955633Z     Path:     /usr/libexec/docker/cli-plugins/docker-compose
> 2026-05-07T04:53:35.7956064Z 
> 2026-05-07T04:53:35.7956369Z Server:
> 2026-05-07T04:53:35.7956765Z  Containers: 1
> 2026-05-07T04:53:35.7957183Z   Running: 1
> 2026-05-07T04:53:35.7957531Z   Paused: 0
> 2026-05-07T04:53:35.7958012Z   Stopped: 0
> 2026-05-07T04:53:35.7958394Z  Images: 7
> 2026-05-07T04:53:35.7958746Z  Server Version: 28.0.4
> 2026-05-07T04:53:35.7959159Z  Storage Driver: overlay2
> 2026-05-07T04:53:35.7959594Z   Backing Filesystem: extfs
> 2026-05-07T04:53:35.7960037Z   Supports d_type: true
> 2026-05-07T04:53:35.7960438Z   Using metacopy: false
> 2026-05-07T04:53:35.7960840Z   Native Overlay Diff: false
> 2026-05-07T04:53:35.7961268Z   userxattr: false
> 2026-05-07T04:53:35.7962306Z  Logging Driver: json-file
> 2026-05-07T04:53:35.7962736Z  Cgroup Driver: systemd
> 2026-05-07T04:53:35.7963129Z  Cgroup Version: 2
> 2026-05-07T04:53:35.7963489Z  Plugins:
> 2026-05-07T04:53:35.7963821Z   Volume: local
> 2026-05-07T04:53:35.7964321Z   Network: bridge host ipvlan macvlan null overlay
> 2026-05-07T04:53:35.7965378Z   Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
> 2026-05-07T04:53:35.7966158Z  Swarm: inactive
> 2026-05-07T04:53:35.7966627Z  Runtimes: io.containerd.runc.v2 runc
> 2026-05-07T04:53:35.7967133Z  Default Runtime: runc
> 2026-05-07T04:53:35.7967556Z  Init Binary: docker-init
> 2026-05-07T04:53:35.7968189Z  containerd version: 301b2dac98f15c27117da5c8af12118a041a31d9
> 2026-05-07T04:53:35.7968870Z  runc version: v1.3.4-0-gd6d73eb8
> 2026-05-07T04:53:35.7969906Z  init version: de40ad0
> 2026-05-07T04:53:35.7970329Z  Security Options:
> 2026-05-07T04:53:35.7970881Z   apparmor
> 2026-05-07T04:53:35.7971095Z   seccomp
> 2026-05-07T04:53:35.7971296Z    Profile: builtin
> 2026-05-07T04:53:35.7971519Z   cgroupns
> 2026-05-07T04:53:35.7971765Z  Kernel Version: 6.17.0-1010-azure
> 2026-05-07T04:53:35.7972087Z  Operating System: Ubuntu 24.04.4 LTS
> 2026-05-07T04:53:35.7972365Z  OSType: linux
> 2026-05-07T04:53:35.7972589Z  Architecture: x86_64
> 2026-05-07T04:53:35.7972816Z  CPUs: 4
> 2026-05-07T04:53:35.7973017Z  Total Memory: 15.61GiB
> 2026-05-07T04:53:35.7973257Z  Name: runnervmeorf1
> 2026-05-07T04:53:35.7973745Z  ID: e27c7740-8587-4822-9bec-fa47c65630a3
> 2026-05-07T04:53:35.7974343Z  Docker Root Dir: /var/lib/docker
> 2026-05-07T04:53:35.7975002Z  Debug Mode: false
> 2026-05-07T04:53:35.7975421Z  Username: githubactions
> 2026-05-07T04:53:35.7975975Z  Experimental: false
> 2026-05-07T04:53:35.7976226Z  Insecure Registries:
> 2026-05-07T04:53:35.7976476Z   ::1/128
> 2026-05-07T04:53:35.7976685Z   127.0.0.0/8
> 2026-05-07T04:53:35.7976901Z  Live Restore Enabled: false
> 2026-05-07T04:53:35.7977069Z 
> 2026-05-07T04:53:35.7977401Z ##[endgroup]
> 2026-05-07T04:53:35.7977837Z ##[group]Proxy configuration
> 2026-05-07T04:53:35.7978351Z No proxy configuration found
> 2026-05-07T04:53:35.7979021Z ##[endgroup]
> 2026-05-07T04:53:35.8515397Z ##[group]Buildx version
> 2026-05-07T04:53:35.8540034Z [command]/usr/bin/docker buildx version
> 2026-05-07T04:53:35.9052275Z github.com/docker/buildx v0.33.0 f7897eba028583e0071642db3c011e860444f8cf
> 2026-05-07T04:53:35.9074488Z ##[endgroup]
> 2026-05-07T04:53:35.9075434Z ##[group]Builder info
> 2026-05-07T04:53:35.9929909Z {
> 2026-05-07T04:53:35.9930398Z   "nodes": [
> 2026-05-07T04:53:35.9930794Z     {
> 2026-05-07T04:53:35.9931248Z       "name": "builder-cfa1f0a3-c7e4-471c-8edf-6c52dc82cc890",
> 2026-05-07T04:53:35.9931715Z       "endpoint": "unix:///var/run/docker.sock",
> 2026-05-07T04:53:35.9932057Z       "status": "running",
> 2026-05-07T04:53:35.9932666Z       "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
> 2026-05-07T04:53:35.9933282Z       "buildkit": "v0.29.0",
> 2026-05-07T04:53:35.9933703Z       "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/386",
> 2026-05-07T04:53:35.9934117Z       "features": {
> 2026-05-07T04:53:35.9934511Z         "Automatically load images to the Docker Engine image store": true,
> 2026-05-07T04:53:35.9934910Z         "Cache export": true,
> 2026-05-07T04:53:35.9935633Z         "Direct push": true,
> 2026-05-07T04:53:35.9936077Z         "Docker exporter": true,
> 2026-05-07T04:53:35.9936410Z         "Multi-platform build": true,
> 2026-05-07T04:53:35.9936720Z         "OCI exporter": true
> 2026-05-07T04:53:35.9936971Z       },
> 2026-05-07T04:53:35.9937173Z       "labels": {
> 2026-05-07T04:53:35.9937510Z         "org.mobyproject.buildkit.worker.executor": "oci",
> 2026-05-07T04:53:35.9938032Z         "org.mobyproject.buildkit.worker.hostname": "31df69f22873",
> 2026-05-07T04:53:35.9938518Z         "org.mobyproject.buildkit.worker.network": "host",
> 2026-05-07T04:53:35.9939033Z         "org.mobyproject.buildkit.worker.oci.process-mode": "sandbox",
> 2026-05-07T04:53:35.9939555Z         "org.mobyproject.buildkit.worker.selinux.enabled": "false",
> 2026-05-07T04:53:35.9940442Z         "org.mobyproject.buildkit.worker.snapshotter": "overlayfs"
> 2026-05-07T04:53:35.9940808Z       },
> 2026-05-07T04:53:35.9941007Z       "gcPolicy": [
> 2026-05-07T04:53:35.9941222Z         {
> 2026-05-07T04:53:35.9941419Z           "all": false,
> 2026-05-07T04:53:35.9941655Z           "filter": [
> 2026-05-07T04:53:35.9941920Z             "type==source.local",
> 2026-05-07T04:53:35.9942225Z             "type==exec.cachemount",
> 2026-05-07T04:53:35.9942545Z             "type==source.git.checkout"
> 2026-05-07T04:53:35.9942820Z           ],
> 2026-05-07T04:53:35.9943058Z           "keepDuration": "48h0m0s",
> 2026-05-07T04:53:35.9943371Z           "maxUsedSpace": "488.3MiB"
> 2026-05-07T04:53:35.9943620Z         },
> 2026-05-07T04:53:35.9943806Z         {
> 2026-05-07T04:53:35.9944141Z           "all": false,
> 2026-05-07T04:53:35.9944402Z           "keepDuration": "1440h0m0s",
> 2026-05-07T04:53:35.9944712Z           "reservedSpace": "9.313GiB",
> 2026-05-07T04:53:35.9945009Z           "maxUsedSpace": "93.13GiB",
> 2026-05-07T04:53:35.9945694Z           "minFreeSpace": "27.01GiB"
> 2026-05-07T04:53:35.9945977Z         },
> 2026-05-07T04:53:35.9946300Z         {
> 2026-05-07T04:53:35.9946636Z           "all": false,
> 2026-05-07T04:53:35.9947117Z           "reservedSpace": "9.313GiB",
> 2026-05-07T04:53:35.9947524Z           "maxUsedSpace": "93.13GiB",
> 2026-05-07T04:53:35.9948057Z           "minFreeSpace": "27.01GiB"
> 2026-05-07T04:53:35.9948422Z         },
> 2026-05-07T04:53:35.9948697Z         {
> 2026-05-07T04:53:35.9949063Z           "all": true,
> 2026-05-07T04:53:35.9949445Z           "reservedSpace": "9.313GiB",
> 2026-05-07T04:53:35.9949860Z           "maxUsedSpace": "93.13GiB",
> 2026-05-07T04:53:35.9973316Z           "minFreeSpace": "27.01GiB"
> 2026-05-07T04:53:35.9973863Z         }
> 2026-05-07T04:53:35.9974099Z       ]
> 2026-05-07T04:53:35.9974361Z     }
> 2026-05-07T04:53:35.9974584Z   ],
> 2026-05-07T04:53:35.9975105Z   "name": "builder-cfa1f0a3-c7e4-471c-8edf-6c52dc82cc89",
> 2026-05-07T04:53:35.9975800Z   "driver": "docker-container",
> 2026-05-07T04:53:35.9976317Z   "lastActivity": "2026-05-07T04:53:29.000Z"
> 2026-05-07T04:53:35.9976623Z }
> 2026-05-07T04:53:35.9977206Z ##[endgroup]
> 2026-05-07T04:53:36.1399881Z [command]/usr/bin/docker buildx build --build-arg APP_COMMIT=58c98d82f61e3850d08b12c55dab612932b5782f --cache-from type=gha --cache-to type=gha,mode=max --iidfile /home/runner/work/_temp/docker-actions-toolkit-fQi6ss/build-iidfile-3b51347769.txt --attest type=provenance,mode=max,builder-id=https://github.com/BMeyn/oche/actions/runs/25476744694/attempts/1 --tag ghcr.io/BMeyn/oche:1.2.0 --tag ghcr.io/BMeyn/oche:latest --metadata-file /home/runner/work/_temp/docker-actions-toolkit-fQi6ss/build-metadata-5c6998ca4c.json --push .
> 2026-05-07T04:53:36.2359441Z ERROR: failed to build: invalid tag "ghcr.io/BMeyn/oche:1.2.0": repository name must be lowercase
> 2026-05-07T04:53:36.2409335Z ##[group]Reference
> 2026-05-07T04:53:36.3236009Z No build reference found
> 2026-05-07T04:53:36.3237013Z ##[endgroup]
> 2026-05-07T04:53:36.3238800Z ##[group]Check build summary support
> 2026-05-07T04:53:36.3242249Z Build summary requires a build reference
> 2026-05-07T04:53:36.3243396Z ##[endgroup]
> 2026-05-07T04:53:36.3271686Z ##[error]buildx failed with: ERROR: failed to build: invalid tag "ghcr.io/BMeyn/oche:1.2.0": repository name must be lowercase

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)