### PR TITLE
Add authenticated Grafana dashboard to Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,12 @@ RESEND_FROM_DOMAIN=contact.oche.cloud
 # DOMAIN=:80          ← HTTP-only (IP-only / no cert)
 # DOMAIN=oche.cloud   ← HTTPS via Let's Encrypt
 DOMAIN=:80
+
+# ─── Grafana (monitoring dashboard) ──────────────────────────────
+# Reachable at https://grafana.<DOMAIN> when DOMAIN is a real hostname.
+# Requires a DNS A record `grafana.<DOMAIN>` → VPS IP for Let's Encrypt.
+# For local dev: uncomment the 127.0.0.1:3001 port mapping on the grafana
+# service in docker-compose.yml and visit http://localhost:3001.
+GRAFANA_ADMIN_USER=admin
+# REQUIRED — pick a strong password (e.g. `openssl rand -base64 24`).
+GRAFANA_ADMIN_PASSWORD=change-me-please

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -40,3 +40,33 @@
 		level INFO
 	}
 }
+
+# Grafana monitoring dashboard.
+# Only reachable when DOMAIN is a real hostname (e.g. oche.cloud) — the
+# block matches `grafana.<DOMAIN>` and Caddy will obtain a Let's Encrypt
+# cert automatically. For local dev (DOMAIN=:80) this block is inert;
+# uncomment the `127.0.0.1:3001:3000` port mapping on the grafana service
+# in docker-compose.yml to access it directly.
+#
+# Auth is enforced by Grafana itself (admin login, sign-up disabled,
+# anonymous disabled — see GF_* env vars in docker-compose.yml).
+grafana.{$DOMAIN} {
+	encode zstd gzip
+
+	reverse_proxy grafana:3000 {
+		header_up X-Real-IP {remote_host}
+	}
+
+	header {
+		-Server
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+	}
+
+	log {
+		output stdout
+		format console
+		level INFO
+	}
+}

--- a/claude.md
+++ b/claude.md
@@ -235,7 +235,18 @@ AUTH_SECRET=                # openssl rand -hex 32
 RESEND_API_KEY=             # from resend.com (optional in dev — logs link to console)
 RESEND_FROM_DOMAIN=contact.oche.cloud  # Resend-verified sending domain
 DOMAIN=oche.cloud           # Caddy domain (NO :80 suffix — breaks HTTPS)
+GRAFANA_ADMIN_USER=admin    # Grafana login user (defaults to admin)
+GRAFANA_ADMIN_PASSWORD=     # Grafana login password — required for monitoring dashboard
 ```
+
+The Grafana dashboard lives at `https://grafana.${DOMAIN}` (Caddy proxies it,
+auto-HTTPS). Provisioned read-only datasource + dashboard live in `grafana/`:
+
+- `grafana/provisioning/datasources/postgres.yml` — Postgres datasource (uses POSTGRES_* env vars)
+- `grafana/provisioning/dashboards/dashboards.yml` — file provider pointing at the dashboards folder
+- `grafana/dashboards/oche-overview.json` — single dashboard: registered users, games-by-status, active games table, DB size
+
+Set up DNS: `grafana.<your-domain>` A record → VPS IP. The dashboard panels run pure SQL against the live DB; they re-use the `displayName` fallback (`COALESCE(NULLIF(TRIM(display_name),''), split_part(email,'@',1))`) so player names match the app UI.
 
 ## DB migrations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@
 # Spins up:
 #   - app     : the Next.js scoring app (port 3000, internal)
 #   - db      : Postgres 16 (data persisted in named volume)
-#   - caddy   : reverse proxy fronting the app (ports 80 / 443)
+#   - grafana : monitoring dashboard, talks to db (admin-auth gated)
+#   - caddy   : reverse proxy fronting app + grafana (ports 80 / 443)
 #
 # Local:  docker compose up -d  →  http://localhost
 # VPS:    same — open ports 80/443 in your firewall, point at server IP
@@ -51,6 +52,36 @@ services:
     networks:
       - oche-net
 
+  grafana:
+    image: grafana/grafana-oss:11.3.0
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
+      # Datasource provisioning reads these via env interpolation.
+      - POSTGRES_USER=${POSTGRES_USER:-oche}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB:-oche}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    expose:
+      - "3000"
+    networks:
+      - oche-net
+    # Uncomment for local dev access without going through Caddy:
+    # ports:
+    #   - "127.0.0.1:3001:3000"
+
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
@@ -66,6 +97,7 @@ services:
       - DOMAIN=${DOMAIN:-:80}
     depends_on:
       - app
+      - grafana
     networks:
       - oche-net
 
@@ -73,6 +105,7 @@ volumes:
   postgres-data:
   caddy-data:
   caddy-config:
+  grafana-data:
 
 networks:
   oche-net:

--- a/grafana/dashboards/oche-overview.json
+++ b/grafana/dashboards/oche-overview.json
@@ -1,0 +1,213 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Registered users",
+      "id": 1,
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "postgres", "uid": "oche-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "postgres", "uid": "oche-postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT COUNT(*)::bigint AS value FROM users;"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Games by status",
+      "id": 2,
+      "gridPos": { "x": 6, "y": 0, "w": 12, "h": 4 },
+      "datasource": { "type": "postgres", "uid": "oche-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "postgres", "uid": "oche-postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  COUNT(*) FILTER (WHERE status = 'waiting')::bigint  AS waiting,\n  COUNT(*) FILTER (WHERE status = 'active')::bigint   AS active,\n  COUNT(*) FILTER (WHERE status = 'finished')::bigint AS finished\nFROM games;"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "active" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "waiting" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "finished" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "purple" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Database size",
+      "id": 3,
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "postgres", "uid": "oche-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "postgres", "uid": "oche-postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT pg_database_size(current_database())::bigint AS bytes;"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 524288000 },
+              { "color": "red", "value": 2147483648 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "type": "table",
+      "title": "Active games",
+      "id": 4,
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 10 },
+      "datasource": { "type": "postgres", "uid": "oche-postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "postgres", "uid": "oche-postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  g.id,\n  g.status,\n  COALESCE(NULLIF(TRIM(u1.display_name), ''), split_part(u1.email, '@', 1)) AS player1,\n  COALESCE(NULLIF(TRIM(u2.display_name), ''), split_part(u2.email, '@', 1), '(guest)') AS player2,\n  g.config->>'mode'          AS mode,\n  g.config->>'startingScore' AS starting_score,\n  g.created_at,\n  g.started_at\nFROM games g\nLEFT JOIN users u1 ON u1.id = g.player1_id\nLEFT JOIN users u2 ON u2.id = g.player2_id\nWHERE g.status IN ('waiting','active')\nORDER BY g.created_at DESC;"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "filterable": true
+          },
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "id" },
+            "properties": [{ "id": "custom.width", "value": 290 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "status" },
+            "properties": [
+              { "id": "custom.width", "value": 90 },
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "active":  { "color": "green",  "index": 0 } } },
+                  { "type": "value", "options": { "waiting": { "color": "yellow", "index": 1 } } }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-text" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": { "show": false, "reducer": ["sum"], "fields": "" }
+      },
+      "transformations": []
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["oche"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "OCHE Overview",
+  "uid": "oche-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: oche
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/postgres.yml
+++ b/grafana/provisioning/datasources/postgres.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+# Provisioned at Grafana startup. Reads $POSTGRES_* from the container env
+# (see docker-compose.yml). Marked editable: false so dashboards can't
+# accidentally mutate it via the UI.
+datasources:
+  - name: oche-postgres
+    type: postgres
+    uid: oche-postgres
+    access: proxy
+    url: db:5432
+    user: ${POSTGRES_USER}
+    isDefault: true
+    secureJsonData:
+      password: ${POSTGRES_PASSWORD}
+    jsonData:
+      database: ${POSTGRES_DB}
+      sslmode: disable
+      postgresVersion: 1600
+      timescaledb: false
+    editable: false


### PR DESCRIPTION
## Summary

All changes look clean. Done.

**Summary of changes**

New files:
- `grafana/provisioning/datasources/postgres.yml` — Postgres datasource (uses `${POSTGRES_*}` env, `editable: false`)
- `grafana/provisioning/dashboards/dashboards.yml` — file provider for the dashboards folder
- `grafana/dashboards/oche-overview.json` — single dashboard with 4 panels: registered users, games-by-status tiles, active games table, DB size

Modified:
- `docker-compose.yml` — added `grafana` service (image `grafana/grafana-oss:11.3.0`, internal-only, depends on healthy db, mounts provisioning + dashboards) and `grafana-data` volume; caddy now also depends on grafana
- `caddy/Caddyfile` — added `grafana.{$DOMAIN}` site block reverse-proxying to `grafana:3000`, with HSTS/Referrer/no-Server-header
- `.env.example` — added `GRAFANA_ADMIN_USER` + required `GRAFANA_ADMIN_PASSWORD`
- `claude.md` — added Grafana env vars + a paragraph explaining `grafana/` layout and the `displayName` SQL parity

**Verified**
- `docker compose config` parses cleanly (only env-var warnings, no syntax errors)
- Caddyfile validates with `caddy validate`
- Provisioning YAML and dashboard JSON parse cleanly

**To run**
```
# add to .env: GRAFANA_ADMIN_PASSWORD=...   (or `openssl rand -base64 24`)
docker compose up -d --build
docker compose logs -f grafana   # watch for "HTTP Server Listen" + provisioning success
```
For local access without Caddy, uncomment the `127.0.0.1:3001:3000` port mapping in `docker-compose.yml`. For the VPS, add a `grafana.oche.cloud` A record → VPS IP and Caddy pulls a Let's Encrypt cert automatically.

## Commits

- `3e6c032` feat: Add authenticated Grafana dashboard to Compose

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

The interactive plan-approval tool is failing with the same runtime error. The plan is written to `/Users/meyn/.claude/plans/i-want-to-add-shimmying-fog.md` — here's a quick summary so you can review:

**Approach:** Add a single `grafana` service to `docker-compose.yml` on the existing `oche-net` network, talking directly to Postgres via Grafana's built-in datasource (no Prometheus, no exporters). Provision one read-only datasource and one default dashboard via mounted YAML/JSON. Route via Caddy as `grafana.oche.cloud` with auto-HTTPS. Auth via Grafana admin login (env-var password).

**Two assumptions I'd like you to confirm or correct:**
1. **Exposure:** subdomain `grafana.oche.cloud` (needs a DNS A record). Alternative: localhost-bind + SSH tunnel for zero internet exposure.
2. **"Available DB memory usage":** interpreted as `pg_database_size(...)` (DB size on disk). True free-volume-space needs `node_exporter` — extra service. Say the word and I'll add it.

**New files:** `grafana/provisioning/datasources/postgres.yml`, `grafana/provisioning/dashboards/dashboards.yml`, `grafana/dashboards/oche-overview.json`.
**Modified:** `docker-compose.yml`, `caddy/Caddyfile`, `.env.example`, `CLAUDE.md`.

**Dashboard panels:** registered users count · games-by-status tiles (waiting/active/finished) · active games table (using the same `display_name ?? email-prefix` logic as `lib/display.ts`) · DB size gauge.

Since `ExitPlanMode` is erroring out, please reply with either "approved" / "go ahead" (and your answers to the two assumptions if you want to override defaults), or any changes you'd like, and I'll execute from there.

</details>

## Original Request

**Add authenticated Grafana dashboard to Compose**

> I want to add a Grafana dashboard to the Docker Compose setup. It should connect to the Postgres DB to show:
> 
> - number of registered users  
> - active games info  
> - available DB memory usage  
> 
> Grafana needs authentication so only I can access it.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)