### PR TITLE
Add game statistics view with burndown chart

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -1,0 +1,25 @@
+import { getCurrentUser } from "@/lib/auth";
+import { getGame } from "@/lib/db/games";
+import { redirect, notFound } from "next/navigation";
+import { GameDetailPage } from "@/components/history/GameDetailPage";
+
+export const dynamic = "force-dynamic";
+
+export default async function GameDetailServerPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [user, game] = await Promise.all([getCurrentUser(), getGame(id)]);
+
+  if (!user) redirect("/login");
+  if (!game) notFound();
+  if (game.status !== "finished" || !game.matchState) notFound();
+
+  const isParticipant =
+    game.player1Id === user.id || game.player2Id === user.id;
+  if (!isParticipant) notFound();
+
+  return <GameDetailPage game={game} currentUserId={user.id} />;
+}

--- a/components/history/BurndownChart.tsx
+++ b/components/history/BurndownChart.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import type { CompletedLeg } from "@/lib/types";
+
+interface Props {
+  leg: CompletedLeg;
+  players: [string, string];
+  startingScore: number;
+}
+
+const COLORS: [string, string] = ["#d4ff3a", "#e63946"];
+const W = 720;
+const H = 280;
+const PAD_L = 44;
+const PAD_R = 56;
+const PAD_T = 16;
+const PAD_B = 28;
+
+export function BurndownChart({ leg, players, startingScore }: Props) {
+  const turns0 = leg.turns[0];
+  const turns1 = leg.turns[1];
+  const maxTurns = Math.max(turns0.length, turns1.length);
+
+  // Build per-player series: index 0 = startingScore, then remainingAfter per turn
+  const series: [number[], number[]] = [
+    [startingScore, ...turns0.map((t) => t.remainingAfter)],
+    [startingScore, ...turns1.map((t) => t.remainingAfter)],
+  ];
+
+  const innerW = W - PAD_L - PAD_R;
+  const innerH = H - PAD_T - PAD_B;
+  const xCount = Math.max(maxTurns, 1);
+
+  const xAt = (i: number) => PAD_L + (i / xCount) * innerW;
+  const yAt = (v: number) => PAD_T + (1 - v / startingScore) * innerH;
+
+  // Y-axis ticks: 0, 100, 200, ..., startingScore
+  const yTicks: number[] = [];
+  for (let v = 0; v <= startingScore; v += 100) yTicks.push(v);
+  if (yTicks[yTicks.length - 1] !== startingScore) yTicks.push(startingScore);
+
+  // X-axis ticks: every turn (cap labels if too many)
+  const xTickStep = maxTurns <= 12 ? 1 : Math.ceil(maxTurns / 10);
+
+  const buildPath = (pts: number[]): string =>
+    pts.map((v, i) => `${i === 0 ? "M" : "L"} ${xAt(i)} ${yAt(v)}`).join(" ");
+
+  return (
+    <div className="border border-border-soft p-4" style={{ background: "#0d1210" }}>
+      <div className="flex items-center justify-between mb-3 flex-wrap gap-3">
+        <div
+          className="f-mono text-[10px] uppercase text-muted"
+          style={{ letterSpacing: "0.22em" }}
+        >
+          Score remaining · Leg {leg.number}
+        </div>
+        <div className="flex items-center gap-4">
+          {([0, 1] as const).map((p) => (
+            <div key={p} className="flex items-center gap-1.5">
+              <span
+                className="inline-block"
+                style={{ width: 14, height: 2, background: COLORS[p] }}
+              />
+              <span className="f-mono text-[10px] uppercase text-cream" style={{ letterSpacing: "0.18em" }}>
+                {players[p]}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-auto" role="img" aria-label="Burndown chart">
+        {/* Y-axis gridlines + labels */}
+        {yTicks.map((v) => (
+          <g key={`y-${v}`}>
+            <line
+              x1={PAD_L}
+              x2={W - PAD_R}
+              y1={yAt(v)}
+              y2={yAt(v)}
+              stroke="#2a332d"
+              strokeWidth={1}
+              strokeDasharray={v === 0 || v === startingScore ? "" : "2 3"}
+            />
+            <text
+              x={PAD_L - 8}
+              y={yAt(v) + 3}
+              fontSize="9"
+              fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+              fill="#6d736f"
+              textAnchor="end"
+            >
+              {v}
+            </text>
+          </g>
+        ))}
+
+        {/* X-axis labels (turn numbers) */}
+        {Array.from({ length: maxTurns + 1 }).map((_, i) => {
+          if (i === 0 || (i % xTickStep !== 0 && i !== maxTurns)) return null;
+          return (
+            <text
+              key={`x-${i}`}
+              x={xAt(i)}
+              y={H - PAD_B + 14}
+              fontSize="9"
+              fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+              fill="#6d736f"
+              textAnchor="middle"
+            >
+              {i}
+            </text>
+          );
+        })}
+        <text
+          x={PAD_L + innerW / 2}
+          y={H - 4}
+          fontSize="8"
+          fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+          fill="#454b47"
+          textAnchor="middle"
+          letterSpacing="2"
+        >
+          TURN
+        </text>
+
+        {/* Lines + points + end labels */}
+        {([0, 1] as const).map((p) => {
+          const pts = series[p];
+          if (pts.length < 2) return null;
+          const lastIdx = pts.length - 1;
+          return (
+            <g key={`line-${p}`}>
+              <path d={buildPath(pts)} fill="none" stroke={COLORS[p]} strokeWidth={2} strokeLinejoin="round" />
+              {pts.map((v, i) => (
+                <circle key={i} cx={xAt(i)} cy={yAt(v)} r={2.5} fill={COLORS[p]} />
+              ))}
+              <text
+                x={xAt(lastIdx) + 6}
+                y={yAt(pts[lastIdx]) + 3}
+                fontSize="11"
+                fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+                fill={COLORS[p]}
+                fontWeight="700"
+              >
+                {pts[lastIdx]}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/components/history/GameDetailPage.tsx
+++ b/components/history/GameDetailPage.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Crown } from "lucide-react";
+import { BrandMark, Tag } from "@/components/ui/primitives";
+import { computeStats } from "@/lib/scoring";
+import { ruleLabel } from "@/lib/format";
+import type { Game, PlayerStats } from "@/lib/types";
+import { BurndownChart } from "./BurndownChart";
+
+interface Props {
+  game: Game;
+  currentUserId: number;
+}
+
+export function GameDetailPage({ game, currentUserId }: Props) {
+  const router = useRouter();
+  const match = game.matchState!;
+  const [legIdx, setLegIdx] = useState(0);
+
+  const stats = useMemo(() => computeStats(match), [match]);
+
+  const winner = match.winner!;
+  const loser = (1 - winner) as 0 | 1;
+
+  // Player perspective for W/L tag
+  const myIdx: 0 | 1 = game.player1Id === currentUserId ? 0 : 1;
+  const myResult = match.winner === myIdx ? "win" : "loss";
+
+  const durationMin =
+    match.endedAt && match.startedAt
+      ? Math.round((match.endedAt - match.startedAt) / 60000)
+      : 0;
+
+  const isX01 = match.config.mode === "x01";
+  const isHighLow = match.config.mode === "highlow";
+  const legs = match.legHistory;
+  const safeLegIdx = Math.min(legIdx, Math.max(legs.length - 1, 0));
+  const selectedLeg = legs[safeLegIdx];
+
+  return (
+    <div className="min-h-screen flex flex-col bg-ink">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft">
+        <BrandMark />
+        <button
+          onClick={() => router.push("/history")}
+          className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
+          style={{ letterSpacing: "0.18em" }}
+        >
+          <ArrowLeft className="w-3.5 h-3.5" /> History
+        </button>
+      </div>
+
+      <div className="flex-1 px-6 py-10 max-w-5xl w-full mx-auto">
+        <div className="rise">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="h-px w-10 bg-electric" />
+            <span
+              className="f-mono text-xs uppercase text-electric"
+              style={{ letterSpacing: "0.25em" }}
+            >
+              game detail
+              {durationMin > 0 && ` · ${durationMin}m`}
+              {isX01 && ` · ${match.config.startingScore} ${ruleLabel(match.config)}`}
+              {isHighLow && " · HIGH-LOW"}
+            </span>
+          </div>
+
+          <div className="mb-3 flex items-end gap-4 flex-wrap">
+            <h1
+              className="f-display font-black leading-[0.9] text-cream"
+              style={{ fontSize: "clamp(36px, 6vw, 64px)" }}
+            >
+              {match.config.players[0].toUpperCase()}{" "}
+              <span className="text-muted">vs</span>{" "}
+              {match.config.players[1].toUpperCase()}
+            </h1>
+          </div>
+
+          <div className="flex items-center gap-3 mb-8 flex-wrap">
+            <Tag color={myResult === "win" ? "#d4ff3a" : "#e63946"}>
+              {myResult === "win" ? "you won" : "you lost"}
+            </Tag>
+            <span className="f-mono text-sm text-bone">
+              {match.legsWon[winner]}–{match.legsWon[loser]} legs
+            </span>
+            <span className="f-serif italic text-bone text-sm">
+              "the chalk is final."
+            </span>
+          </div>
+
+          {/* Burndown — X01 only */}
+          {isX01 && legs.length > 0 && (
+            <section className="mb-10">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="h-px w-6 bg-border" />
+                <span
+                  className="f-mono text-xs uppercase text-muted"
+                  style={{ letterSpacing: "0.25em" }}
+                >
+                  Burndown
+                </span>
+              </div>
+
+              {legs.length > 1 && (
+                <div className="flex flex-wrap gap-1.5 mb-3">
+                  {legs.map((leg, i) => (
+                    <button
+                      key={leg.number}
+                      onClick={() => setLegIdx(i)}
+                      className="f-mono text-[11px] uppercase px-3 py-1.5 border"
+                      style={{
+                        letterSpacing: "0.18em",
+                        borderColor: i === safeLegIdx ? "#d4ff3a" : "#2a332d",
+                        background: i === safeLegIdx ? "#1c2420" : "transparent",
+                        color: i === safeLegIdx ? "#d4ff3a" : "#a8a8a8",
+                      }}
+                    >
+                      Leg {leg.number}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {selectedLeg && (
+                <BurndownChart
+                  leg={selectedLeg}
+                  players={match.config.players}
+                  startingScore={match.config.startingScore}
+                />
+              )}
+            </section>
+          )}
+
+          {/* High-Low: per-leg best 3-dart total table */}
+          {isHighLow && legs.length > 0 && (
+            <section className="mb-10">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="h-px w-6 bg-border" />
+                <span
+                  className="f-mono text-xs uppercase text-muted"
+                  style={{ letterSpacing: "0.25em" }}
+                >
+                  Best 3-dart per leg
+                </span>
+              </div>
+              <div className="border border-border-soft" style={{ background: "#0d1210" }}>
+                <div className="grid grid-cols-4 px-4 py-2 border-b border-border-soft f-mono text-[10px] uppercase text-muted" style={{ letterSpacing: "0.2em" }}>
+                  <div>Leg</div>
+                  <div>{match.config.players[0]}</div>
+                  <div>{match.config.players[1]}</div>
+                  <div>Winner</div>
+                </div>
+                {legs.map((leg) => {
+                  const best0 = leg.turns[0].reduce((m, t) => Math.max(m, t.rawTotal), 0);
+                  const best1 = leg.turns[1].reduce((m, t) => Math.max(m, t.rawTotal), 0);
+                  return (
+                    <div
+                      key={leg.number}
+                      className="grid grid-cols-4 px-4 py-2.5 border-b border-border-soft last:border-b-0 f-mono text-sm"
+                    >
+                      <div className="text-muted">#{leg.number}</div>
+                      <div className={leg.winner === 0 ? "text-electric font-bold" : "text-bone"}>{best0}</div>
+                      <div className={leg.winner === 1 ? "text-electric font-bold" : "text-bone"}>{best1}</div>
+                      <div className="text-cream">{match.config.players[leg.winner]}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Stats comparison */}
+          <section className="mb-10">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="h-px w-6 bg-border" />
+              <span
+                className="f-mono text-xs uppercase text-muted"
+                style={{ letterSpacing: "0.25em" }}
+              >
+                Comparison
+              </span>
+            </div>
+            <div className="grid md:grid-cols-2 gap-5">
+              {([0, 1] as const).map((i) => (
+                <StatsCard
+                  key={i}
+                  name={match.config.players[i]}
+                  isWinner={i === winner}
+                  stats={stats[i]}
+                />
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatsCard({
+  name, isWinner, stats,
+}: { name: string; isWinner: boolean; stats: PlayerStats }) {
+  return (
+    <div
+      className="border p-6 relative"
+      style={{
+        background: isWinner ? "#1c2420" : "#141a17",
+        borderColor: isWinner ? "#d4ff3a" : "#2a332d",
+      }}
+    >
+      {isWinner && <Crown className="absolute top-4 right-4 w-5 h-5 text-electric" />}
+      <div
+        className="f-mono text-[10px] uppercase mb-1 text-muted"
+        style={{ letterSpacing: "0.24em" }}
+      >
+        {isWinner ? "WINNER" : "RUNNER-UP"}
+      </div>
+      <div className="f-display font-black text-3xl mb-5 text-cream">{name}</div>
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        <MiniStat
+          label="3-DART AVG"
+          value={stats.threeDartAvg.toFixed(2)}
+          highlight={isWinner}
+          wide
+        />
+        <MiniStat label="DARTS" value={stats.totalDarts} />
+        <MiniStat label="LEGS" value={stats.legsWon} />
+      </div>
+      <div className="grid grid-cols-4 gap-2 mb-3">
+        <MiniStat label="180s" value={stats.tonEighty} accent={stats.tonEighty > 0} />
+        <MiniStat label="140+" value={stats.tonForty} />
+        <MiniStat label="100+" value={stats.tons} />
+        <MiniStat label="BEST OUT" value={stats.bestFinish || "—"} />
+      </div>
+      <div className="grid grid-cols-4 gap-2">
+        <MiniStat label="TRIPLES" value={stats.triples} />
+        <MiniStat label="DOUBLES" value={stats.doubles} />
+        <MiniStat label="BULLS" value={stats.bullseyes + stats.bulls25} />
+        <MiniStat label="MISSES" value={stats.misses} muted />
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({
+  label, value, highlight, accent, muted, wide,
+}: {
+  label: string; value: string | number;
+  highlight?: boolean; accent?: boolean; muted?: boolean; wide?: boolean;
+}) {
+  return (
+    <div className="border p-2 bg-ink border-border-soft">
+      <div
+        className="f-mono text-[9px] uppercase text-muted"
+        style={{ letterSpacing: "0.2em" }}
+      >
+        {label}
+      </div>
+      <div
+        className={`f-display font-black ${wide ? "text-2xl" : "text-xl"} mt-0.5`}
+        style={{
+          color: highlight ? "#d4ff3a" : accent ? "#e63946" : muted ? "#454b47" : "#f2e8d0",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/components/history/HistoryPage.tsx
+++ b/components/history/HistoryPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Trophy } from "lucide-react";
+import { ArrowLeft, ChevronRight, Trophy } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
 import type { GameHistoryItem, TournamentHistoryItem } from "@/lib/db/history";
 import type { TournamentFormat, User } from "@/lib/types";
@@ -110,7 +110,16 @@ export function HistoryPage({ games, tournaments, user }: Props) {
                 {games.map((g) => (
                   <div
                     key={g.id}
-                    className="border border-border-soft flex items-center justify-between px-4 py-3 gap-3"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => router.push(`/history/${g.id}`)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        router.push(`/history/${g.id}`);
+                      }
+                    }}
+                    className="border border-border-soft flex items-center justify-between px-4 py-3 gap-3 cursor-pointer hover:border-border transition-colors"
                     style={{
                       background: g.isGuestGame ? "#0c0f0e" : g.result === "win" ? "#0f1a12" : "#0e1010",
                       opacity: g.isGuestGame ? 0.5 : 1,
@@ -154,12 +163,13 @@ export function HistoryPage({ games, tournaments, user }: Props) {
                         <span className="ml-auto">{timeAgo(g.date)}</span>
                       </div>
                     </div>
-                    <div className="shrink-0 text-right">
+                    <div className="shrink-0 text-right flex items-center gap-2">
                       <div className="f-mono text-[10px] text-muted" style={{ letterSpacing: "0.1em" }}>
                         {g.config.mode === "highlow"
                           ? "HIGH-LOW"
                           : `${g.config.startingScore}`}
                       </div>
+                      <ChevronRight className="w-3.5 h-3.5 text-muted" />
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary

Build succeeds. The new `/history/[id]` route is registered (5.13 kB).

**What changed:**

- `app/(app)/history/[id]/page.tsx` (new) — server page that fetches the game via `getGame(id)`, gates on participant + finished status, delegates to client.
- `components/history/GameDetailPage.tsx` (new) — header, W/L tag, leg-tab burndown selector for X01, per-leg "best 3-dart" table for High-Low, and a two-column stats comparison reusing the SummaryScreen idiom.
- `components/history/BurndownChart.tsx` (new) — inline SVG line chart, two players (electric / oche-red), Y ticks at 0/100/.../startingScore, X ticks per turn, end-of-line score labels. No new dependencies.
- `components/history/HistoryPage.tsx` (modified) — game rows are now clickable buttons (with keyboard support and a `ChevronRight` affordance) that navigate to `/history/[id]`.

**Verification done:** `tsc --noEmit` zero errors, `npm test` 24/24 pass, `npm run build` succeeds.

I can't drive the browser from here, so the visual check (chart proportions, leg switching, mobile stack) is on you — open `/history`, click any finished game.

## Commits

- `fa6b95a` feat: Add game statistics view with burndown chart

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Per-game statistics view (burndown + comparison)

## Context

History currently lists finished games as static rows — you can see W/L, avg, 180s, best out, but you can't drill in. The full `Match` (including per-turn `remainingBefore` / `remainingAfter` for every leg) is already persisted in the `match_state` JSONB column, so a per-game detail view is essentially a frontend-only feature: render existing data nicely.

**Goal:** click a game in `/history` → land on a detail view with (1) a leg-by-leg burndown chart for both players and (2) a side-by-side per-player stats comparison.

## Approach

Follow the existing route convention (`/match/[id]`, `/tournament/[id]`): add a new server page `/history/[id]/page.tsx` that fetches the finished game and delegates to a client component.

**No new dependencies.** Render the burndown as a small inline SVG line chart (≈80 lines). It matches the brand aesthetic (custom, condensed, non-generic) better than recharts and avoids ~70KB of bundle weight for a single chart.

## Files to create

### `app/(app)/history/[id]/page.tsx` — server page
- `getCurrentUser()` → redirect if no user
- `getGame(id)` from `lib/db/games.ts` (already exists, returns `Match` in `matchState`)
- 404 if game not found, status ≠ `"finished"`, or user is not `player1Id` / `player2Id`
- Pass `game`, `user` to `<GameDetailPage />`
- `export const dynamic = "force-dynamic"`

### `components/history/GameDetailPage.tsx` — client view
- Header: BrandMark + "← History" back button (matches HistoryPage header)
- Title: `PLAYER A  vs  PLAYER B`, subtitle line with mode/format/duration (reuse phrasing from `SummaryScreen.tsx:38–43`)
- Result tag (W/L from current user's POV, legs `X–Y`)
- **Burndown section** (X01 only — gated on `match.config.mode === "x01"`):
  - Leg selector tabs (`Leg 1`, `Leg 2`, …) using `legHistory` + `currentLeg` if not finished — but since this is `/history`, only `legHistory` is needed (the final leg is in there once `winner !== null`)
  - For the selected leg: `<BurndownChart leg={...} players={[name1, name2]} startingScore={...} />`
- **Stats comparison section**:
  - Two columns side-by-side. Reuse the `StatsCard` / `MiniStat` visual idiom from `components/summary/SummaryScreen.tsx:117–186` but inline a simplified version (no winner crown necessary — just show both, highlight winner subtly).
  - Pull data from `computeStats(match)` → `[stats0, stats1]`.
- **High-Low fallback:** if `mode === "highlow"`, skip burndown and show only the stats comparison plus a per-leg "best 3-dart total" table from `legHistory[].turns[p][...]` (highest `rawTotal` per leg).

### `components/history/BurndownChart.tsx` — inline SVG line chart
- Props: `{ leg: CompletedLeg; players: [string, string]; startingScore: number }`
- Compute two polylines:
  - x: turn index (interleave both players or use the longer of the two as x-axis length; simplest: x = turn index per player → two lines, distinct lengths OK)
  - y: `remainingAfter` after each turn (use `startingScore` as the y=0 anchor at turn 0)
- Brand palette: player 1 line = `#d4ff3a` (electric), player 2 line = `#e63946` (oche-red); muted gridlines (`#2a332d`); background `#0d1210`; axis labels `f-mono text-[9px] uppercase text-muted`
- Y-axis ticks at 0, 100, 200, …, startingScore. X-axis tick per turn. Tooltip not required — render value labels on the last point of each line.
- Width 100% of container (use `viewBox`), height ~280px.

## Files to modify

### `components/history/HistoryPage.tsx`
- Make each game row clickable: wrap the existing `<div key={g.id} ...>` in an `onClick={() => router.push(\`/history/${g.id}\`)}` and add `role="button"` + `cursor-pointer`. Mirror the tournament row treatment at lines 177–207.
- Tiny chevron icon (`ChevronRight` from `lucide-react`) on the right of each game row to telegraph it's clickable.

## Reused functions / utilities

- `getGame(id)` — `lib/db/games.ts:107`
- `computeStats(match)` — `lib/scoring.ts:360`
- `displayName(email, name?)` — `lib/display.ts`
- `ruleLabel(config)` — `lib/format.ts`
- `getCurrentUser()` — `lib/auth.ts`
- Visual primitives: `BrandMark`, `Tag` from `components/ui/primitives.tsx`
- Stats card visual idiom from `components/summary/SummaryScreen.tsx`

## Data already on hand (no DB changes)

For each finished game, the `match_state` JSONB contains:
- `legHistory: CompletedLeg[]` — every completed leg with `turns: [Turn[], Turn[]]`
- Each `Turn` has `remainingBefore`, `remainingAfter`, `total`, `kind`, `darts[]`, `countedDartsCount` — everything the burndown and stats need.
- `legsWon`, `winner`, `startedAt`, `endedAt`, `config`.

So the only DB call in the new page is the existing `getGame(id)`.

## Authorization

Only return the detail view if `user.id === game.player1Id || user.id === game.player2Id`. Otherwise 404 (don't reveal that the game exists). Guest games (`player2Id === null`) are visible only to `player1Id`.

## Verification

1. `npx tsc --noEmit` — zero errors
2. `npm test` — 24/24 pass (no engine changes, but sanity-check)
3. `npm run build` — Next build succeeds
4. **Manual UI check:**
   - Open `/history`, click a finished X01 game → detail view renders with burndown + stat cards
   - Burndown shows two lines descending from `startingScore` to ~0 over the leg's turns
   - Switch leg tabs → chart updates
   - Stats comparison numbers match what's shown on `SummaryScreen` for that match
   - Click a finished High-Low game → no burndown, but per-leg best-3-dart table renders
   - Try opening `/history/<some-other-user's-game-id>` → 404
   - Back button returns to `/history`
   - Mobile viewport: chart stays readable, stat cards stack

</details>

## Original Request

**Add game statistics view with burndown chart**

> I think it would also be nice to have some statistics for the current game, like a burndown chart for the points and some averages—a comparison between both players. It could be implemented as part of the history with an additional menu to access the game statistics.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)