### PR TITLE
Restrict feedback button to lobby view

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
-import { FeedbackButton } from "@/components/ui/FeedbackButton";
 
 // Force dynamic rendering — this layout reads cookies(), so it must never be
 // statically pre-rendered at build time (which would cache the redirect-to-login
@@ -12,10 +11,5 @@ export const dynamic = "force-dynamic";
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
   if (!user) redirect("/login");
-  return (
-    <>
-      {children}
-      <FeedbackButton />
-    </>
-  );
+  return <>{children}</>;
 }

--- a/app/(app)/lobby/page.tsx
+++ b/app/(app)/lobby/page.tsx
@@ -1,6 +1,7 @@
 import { getCurrentUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { LobbyPage } from "@/components/lobby/LobbyPage";
+import { FeedbackButton } from "@/components/ui/FeedbackButton";
 import { getPendingRequests } from "@/lib/db/friends";
 
 export const dynamic = "force-dynamic";
@@ -15,5 +16,10 @@ export default async function Lobby() {
   } catch {
     // friend_requests table may not exist yet (migration pending)
   }
-  return <LobbyPage user={user} pendingFriendRequests={incomingCount} />;
+  return (
+    <>
+      <LobbyPage user={user} pendingFriendRequests={incomingCount} />
+      <FeedbackButton />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Done. `FeedbackButton` removed from `app/(app)/layout.tsx` and now mounted only in `app/(app)/lobby/page.tsx` — it'll render on `/lobby` and nowhere else. To verify in the browser, run `npm run dev`, log in, and confirm the feedback pill is visible on `/lobby` but absent on `/match/[id]`, `/tournament/[id]`, `/history`, and `/settings`.

## Commits

- `429ad62` feat: Restrict feedback button to lobby view
- `90f32fa` chore(release): 1.4.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Restrict feedback button to lobby

## Context

The floating feedback button (lower-left "Feedback" pill) currently appears on **every** authenticated app page — lobby, match, tournament, history, settings — because it's mounted in `app/(app)/layout.tsx`. The user wants feedback discoverable from a single, intentional place (the lobby) rather than overlaying every screen, where it can clutter the match/tournament UIs and compete with primary actions.

Outcome: `FeedbackButton` renders **only** on `/lobby`. All other app routes render without it.

## Change

**File 1 — `app/(app)/layout.tsx`** (remove the button)

- Delete the import: `import { FeedbackButton } from "@/components/ui/FeedbackButton";` (line 3)
- Remove `<FeedbackButton />` (line 18) and collapse the fragment so the layout just returns `children`.

**File 2 — `app/(app)/lobby/page.tsx`** (mount the button here instead)

- Add `import { FeedbackButton } from "@/components/ui/FeedbackButton";`
- Wrap the existing return in a fragment and render `<FeedbackButton />` as a sibling to `<LobbyPage>`:
  ```tsx
  return (
    <>
      <LobbyPage user={user} pendingFriendRequests={incomingCount} />
      <FeedbackButton />
    </>
  );
  ```
- This is a server component rendering a client component — supported in App Router, no `"use client"` needed on the page.

No other changes. `FeedbackButton` itself (`components/ui/FeedbackButton.tsx`) stays untouched — it's already self-contained (modal, fixed positioning, API call to `/api/feedback`).

## Why mount in `page.tsx`, not inside `LobbyPage` component

Keeps the button a peer of the page rather than coupled to lobby's internal layout. If the user later wants to also expose it on, say, `/settings`, it's a one-line addition to that page — no component refactor.

## Verification

1. `npx tsc --noEmit` — zero errors.
2. `npm run dev` and log in:
   - `/lobby` → feedback button visible lower-left, opens modal, submits.
   - `/match/[id]`, `/tournament/[id]`, `/history`, `/settings` → no feedback button.
3. `npm run build` — standalone build succeeds.

</details>

## Original Request

**Restrict feedback button to lobby view**

> That's exciting. Please ensure the feedback button is only available and visible in the lobby.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)