### PR TITLE
Add targeted training mode for darts

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -21,5 +21,8 @@ export default async function GameDetailServerPage({
     game.player1Id === user.id || game.player2Id === user.id;
   if (!isParticipant) notFound();
 
+  // Training sessions don't have a per-leg detail view — bounce back to the list.
+  if (game.matchState.config.mode === "training") redirect("/history");
+
   return <GameDetailPage game={game} currentUserId={user.id} />;
 }

--- a/components/history/HistoryPage.tsx
+++ b/components/history/HistoryPage.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ArrowLeft, ChevronRight, Trophy } from "lucide-react";
+import { ArrowLeft, ChevronRight, Trophy, Target } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
 import type { GameHistoryItem, TournamentHistoryItem } from "@/lib/db/history";
 import type { TournamentFormat, User } from "@/lib/types";
 import { displayName as dn } from "@/lib/display";
+import { drillLabel } from "@/lib/format";
 
 interface Props {
   games: GameHistoryItem[];
@@ -47,8 +48,10 @@ export function HistoryPage({ games, tournaments, user }: Props) {
   const userEmail = user.email;
   const router = useRouter();
 
-  // Aggregate stats — guest games are excluded from stats (but still shown in the list)
-  const rankedGames = games.filter((g) => !g.isGuestGame);
+  // Aggregate stats — guest + training games are excluded from stats (but still shown in the list)
+  const rankedGames = games.filter((g) => !g.isGuestGame && !g.isTraining);
+  const trainingGames = games.filter((g) => g.isTraining);
+  const matchGames = games.filter((g) => !g.isTraining);
   const totalGames = rankedGames.length;
   const wins = rankedGames.filter((g) => g.result === "win").length;
   const winRate = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0;
@@ -102,12 +105,12 @@ export function HistoryPage({ games, tournaments, user }: Props) {
           )}
 
           {/* Games section */}
-          <Section label="Games" count={games.length}>
-            {games.length === 0 ? (
+          <Section label="Games" count={matchGames.length}>
+            {matchGames.length === 0 ? (
               <EmptyState text="No finished games yet." />
             ) : (
               <div className="space-y-1.5">
-                {games.map((g) => (
+                {matchGames.map((g) => (
                   <div
                     key={g.id}
                     role="button"
@@ -177,6 +180,44 @@ export function HistoryPage({ games, tournaments, user }: Props) {
             )}
           </Section>
 
+          {/* Practice section */}
+          {trainingGames.length > 0 && (
+            <Section label="Practice" count={trainingGames.length}>
+              <div className="space-y-1.5">
+                {trainingGames.map((g) => {
+                  const ts = g.trainingSummary!;
+                  const isBust = ts.resultLabel === "BUSTED";
+                  return (
+                    <div
+                      key={g.id}
+                      className="border border-border-soft flex items-center justify-between px-4 py-3 gap-3"
+                      style={{ background: "#0d1210" }}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <Target className="w-3.5 h-3.5 text-electric shrink-0" />
+                          <span className="f-display font-black text-base text-cream">
+                            {drillLabel(ts.drill)}
+                          </span>
+                          <span
+                            className="f-display font-black text-base"
+                            style={{ color: isBust ? "#e63946" : "#d4ff3a" }}
+                          >
+                            {ts.resultLabel}
+                          </span>
+                        </div>
+                        <div className="f-mono text-[11px] text-muted mt-0.5 flex items-center gap-3 flex-wrap">
+                          <span>{ts.metricLabel}</span>
+                          <span className="ml-auto">{timeAgo(g.date)}</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </Section>
+          )}
+
           {/* Tournaments section */}
           <Section label="Tournaments" count={tournaments.length}>
             {tournaments.length === 0 ? (
@@ -219,7 +260,7 @@ export function HistoryPage({ games, tournaments, user }: Props) {
             )}
           </Section>
 
-          {totalGames === 0 && tournaments.length === 0 && (
+          {games.length === 0 && tournaments.length === 0 && (
             <div className="f-mono text-sm text-muted text-center py-16">
               No history yet. Play some games first!
             </div>

--- a/components/lobby/CreateTrainingForm.tsx
+++ b/components/lobby/CreateTrainingForm.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, X } from "lucide-react";
+import type { GameConfig, TrainingDrill } from "@/lib/types";
+import { Label } from "@/components/ui/primitives";
+
+interface Props {
+  onClose: () => void;
+}
+
+export function CreateTrainingForm({ onClose }: Props) {
+  const router = useRouter();
+  const [drill, setDrill] = useState<TrainingDrill>("doubles");
+  const [scenarioCount, setScenarioCount] = useState(10);
+  const [loading, setLoading] = useState(false);
+
+  const create = async () => {
+    setLoading(true);
+    const config: GameConfig = {
+      mode: "training",
+      startingScore: 0,
+      legsToWin: 1,
+      drill,
+      scenarioCount: drill === "checkout" ? scenarioCount : undefined,
+    };
+    const res = await fetch("/api/games", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    });
+    if (res.ok) {
+      const game = await res.json();
+      router.push(`/match/${game.id}`);
+    } else {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "#0a0e0ce8" }}
+    >
+      <div
+        className="w-full max-w-2xl border border-border bg-surface overflow-y-auto"
+        style={{ maxHeight: "90vh" }}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft">
+          <div
+            className="f-mono text-xs uppercase text-electric"
+            style={{ letterSpacing: "0.25em" }}
+          >
+            Practice · solo drill
+          </div>
+          <button onClick={onClose} className="text-muted hover:text-cream">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-6 space-y-6">
+          <div>
+            <Label>Drill</Label>
+            <div className="grid grid-cols-1 gap-2">
+              <DrillCard
+                active={drill === "doubles"}
+                onClick={() => setDrill("doubles")}
+                title="Doubles Practice"
+                subtitle="D1 → BULL"
+                description="Three darts at each double from D1 to D20, then BULL. Track your hit rate and longest streak."
+              />
+              <DrillCard
+                active={drill === "bobs27"}
+                onClick={() => setDrill("bobs27")}
+                title="Bobs 27"
+                subtitle="The classic"
+                description="Start at 27. Each round target a double D1→D20. Hit = +2×n, miss the round = −2×n. Bust at 0, finish at D20."
+              />
+              <DrillCard
+                active={drill === "checkout"}
+                onClick={() => setDrill("checkout")}
+                title="Checkout Practice"
+                subtitle="Random finishes"
+                description="Random checkout from 41–170. Three darts to finish on a double. Tracks success rate and best finish."
+              />
+            </div>
+          </div>
+
+          {drill === "checkout" && (
+            <div>
+              <Label>Scenarios</Label>
+              <div className="grid grid-cols-3 gap-2">
+                {[5, 10, 20].map((n) => (
+                  <OptionButton
+                    key={n}
+                    active={scenarioCount === n}
+                    onClick={() => setScenarioCount(n)}
+                  >
+                    <div className="f-display font-black text-2xl">{n}</div>
+                    <div className="f-mono text-[9px] uppercase" style={{ letterSpacing: "0.2em" }}>
+                      checkouts
+                    </div>
+                  </OptionButton>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="px-6 pb-6">
+          <button
+            onClick={create}
+            disabled={loading}
+            className="w-full f-display font-black text-2xl uppercase py-4 flex items-center justify-center gap-3"
+            style={{
+              background: loading ? "#454b47" : "#d4ff3a",
+              color: loading ? "#6d736f" : "#0a0e0c",
+              cursor: loading ? "not-allowed" : "pointer",
+            }}
+          >
+            {loading ? "Starting…" : <>Start drill <ArrowRight className="w-6 h-6" strokeWidth={3} /></>}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OptionButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className="border p-2.5 flex flex-col items-center justify-center"
+      style={{
+        background: active ? "#d4ff3a" : "#141a17",
+        color: active ? "#0a0e0c" : "#f2e8d0",
+        borderColor: active ? "#d4ff3a" : "#2a332d",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function DrillCard({ active, onClick, title, subtitle, description }: {
+  active: boolean; onClick: () => void; title: string; subtitle: string; description: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="border p-4 text-left"
+      style={{
+        background: active ? "#1c2420" : "#141a17",
+        borderColor: active ? "#d4ff3a" : "#2a332d",
+        boxShadow: active ? "0 0 0 1px #d4ff3a, 0 0 24px -8px #d4ff3a88" : "none",
+      }}
+    >
+      <div className="flex items-baseline justify-between mb-1">
+        <span className="f-display font-black text-2xl" style={{ color: active ? "#d4ff3a" : "#f2e8d0" }}>{title}</span>
+        <span className="f-mono text-[10px] uppercase text-muted" style={{ letterSpacing: "0.2em" }}>{subtitle}</span>
+      </div>
+      <div className="f-mono text-xs text-bone leading-[1.4]">{description}</div>
+    </button>
+  );
+}

--- a/components/lobby/LobbyPage.tsx
+++ b/components/lobby/LobbyPage.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, LogOut, Trophy, Clock } from "lucide-react";
+import { Plus, LogOut, Trophy, Clock, Target } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
 import { CreateGameForm } from "./CreateGameForm";
+import { CreateTrainingForm } from "./CreateTrainingForm";
 import { OpenGames } from "./OpenGames";
 import { CreateTournamentForm } from "@/components/tournament/CreateTournamentForm";
 import { YourTournaments } from "@/components/tournament/YourTournaments";
@@ -21,6 +22,7 @@ export function LobbyPage({ user, pendingFriendRequests }: Props) {
   const router = useRouter();
   const [showCreate, setShowCreate] = useState(false);
   const [showCreateTournament, setShowCreateTournament] = useState(false);
+  const [showCreateTraining, setShowCreateTraining] = useState(false);
 
   const logout = async () => {
     await fetch("/api/auth/logout", { method: "POST" });
@@ -97,6 +99,14 @@ export function LobbyPage({ user, pendingFriendRequests }: Props) {
               <Trophy className="w-5 h-5" strokeWidth={2} />
               Tournament
             </button>
+            <button
+              onClick={() => setShowCreateTraining(true)}
+              className="flex items-center gap-2.5 f-display font-black text-xl uppercase px-6 py-3.5 border border-border"
+              style={{ color: "#f2e8d0" }}
+            >
+              <Target className="w-5 h-5" strokeWidth={2} />
+              Practice
+            </button>
           </div>
 
           <p className="f-mono text-sm text-muted max-w-sm">
@@ -119,6 +129,7 @@ export function LobbyPage({ user, pendingFriendRequests }: Props) {
 
       {showCreate && <CreateGameForm onClose={() => setShowCreate(false)} />}
       {showCreateTournament && <CreateTournamentForm onClose={() => setShowCreateTournament(false)} />}
+      {showCreateTraining && <CreateTrainingForm onClose={() => setShowCreateTraining(false)} />}
     </div>
   );
 }

--- a/components/lobby/OpenGames.tsx
+++ b/components/lobby/OpenGames.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import type { Game, GameConfig } from "@/lib/types";
+import { drillLabel } from "@/lib/format";
 
 function gameLabel(config: GameConfig): string {
+  if (config.mode === "training") return drillLabel(config.drill ?? "doubles");
   if (config.mode === "highlow") return "High-Low";
   const out = config.outRule === "double" ? "Double out" : config.outRule === "master" ? "Master out" : "Straight out";
   return `${config.startingScore} · ${out} · Best of ${config.legsToWin * 2 - 1}`;
@@ -69,13 +71,26 @@ export function OpenGames({ currentUserId }: { currentUserId: number }) {
           >
             <div className="min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="f-mono text-xs text-muted">vs</span>
-                <span className="f-display font-black text-cream text-lg">
-                  {opponentName(game, currentUserId)}
-                </span>
-                <span className="f-mono text-xs text-bone" style={{ letterSpacing: "0.05em" }}>
-                  · {gameLabel(game.config)}
-                </span>
+                {game.config.mode === "training" ? (
+                  <>
+                    <span className="f-mono text-xs uppercase text-electric" style={{ letterSpacing: "0.18em" }}>
+                      practice
+                    </span>
+                    <span className="f-display font-black text-cream text-lg">
+                      {gameLabel(game.config)}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className="f-mono text-xs text-muted">vs</span>
+                    <span className="f-display font-black text-cream text-lg">
+                      {opponentName(game, currentUserId)}
+                    </span>
+                    <span className="f-mono text-xs text-bone" style={{ letterSpacing: "0.05em" }}>
+                      · {gameLabel(game.config)}
+                    </span>
+                  </>
+                )}
               </div>
               <div className="f-mono text-[11px] text-muted mt-0.5 flex items-center gap-2">
                 {game.status === "waiting" ? (

--- a/components/match/MatchScreen.tsx
+++ b/components/match/MatchScreen.tsx
@@ -5,13 +5,14 @@ import { ChevronLeft, Undo2 } from "lucide-react";
 import type { Match, Multiplier } from "@/lib/types";
 import {
   applyDart, displayRemaining, makeDart, undoLastDart, computeStats, sumDarts,
-  isDouble, DART_MISS,
+  isDouble, DART_MISS, trainingCurrentTarget, trainingTotalRounds,
 } from "@/lib/scoring";
 import { checkoutHint } from "@/lib/checkouts";
-import { ruleLabel } from "@/lib/format";
+import { ruleLabel, drillLabel, targetLabel } from "@/lib/format";
 import { Tag } from "@/components/ui/primitives";
 import { PlayerPanel } from "./PlayerPanel";
 import { Keypad } from "./Keypad";
+import { TrainingPanel } from "@/components/training/TrainingPanel";
 
 interface Props {
   match: Match;
@@ -34,9 +35,12 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
   const [legOverlay, setLegOverlay] = useState<LegOverlay | null>(null);
 
   const isX01 = match.config.mode === "x01";
+  const isTraining = match.config.mode === "training";
   const p = match.currentLeg.currentPlayer;
   const liveRemaining = displayRemaining(match, p);
-  const turnDarts = match.currentLeg.currentTurnDarts;
+  const turnDarts = isTraining
+    ? (match.training?.currentDarts ?? [])
+    : match.currentLeg.currentTurnDarts;
   const stats = useMemo(() => computeStats(match), [match]);
 
   const needsDoubleIn =
@@ -71,7 +75,11 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
     setMultiplier(1);
 
     if (outcome === "bust") setToast({ msg: "BUST", kind: "bust" });
-    if (outcome === "leg-won") {
+    if (isTraining && outcome === "leg-won") {
+      // Per-scenario success in Checkout drill
+      setToast({ msg: "CHECKOUT", kind: "info" });
+    }
+    if (!isTraining && outcome === "leg-won") {
       const last = next.legHistory[next.legHistory.length - 1];
       setLegOverlay({
         winner: last.winner,
@@ -99,10 +107,16 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
   };
 
   const turnTotal = sumDarts(turnDarts);
-  const nothingToUndo =
-    turnDarts.length === 0 &&
-    match.currentLeg.turns[0].length === 0 &&
-    match.currentLeg.turns[1].length === 0;
+  const nothingToUndo = isTraining
+    ? turnDarts.length === 0
+    : turnDarts.length === 0 &&
+      match.currentLeg.turns[0].length === 0 &&
+      match.currentLeg.turns[1].length === 0;
+
+  const trainingTarget = isTraining ? trainingCurrentTarget(match.training!) : null;
+  const trainingProgress = isTraining
+    ? `${Math.min(match.training!.cursor + 1, trainingTotalRounds(match.training!, match.config))} / ${trainingTotalRounds(match.training!, match.config)}`
+    : "";
 
   return (
     <div className="min-h-screen flex flex-col bg-ink">
@@ -117,40 +131,56 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
         <div className="flex items-center gap-3 md:gap-5">
           <div className="hidden sm:block">
             <Tag color="#6d736f">
-              {match.config.mode === "x01"
+              {isTraining
+                ? drillLabel(match.training!.drill).toUpperCase()
+                : match.config.mode === "x01"
                 ? `${match.config.startingScore} · ${ruleLabel(match.config)}`
                 : "HIGH-LOW"}
             </Tag>
           </div>
-          <div
-            className="f-mono text-xs text-muted"
-            style={{ letterSpacing: "0.18em" }}
-          >
-            LEG{" "}
-            <span className="f-display font-black text-base ml-1 text-cream">
-              {match.currentLeg.number}
-            </span>
-          </div>
-          <div className="f-display font-black text-xl">
-            <span
-              style={{
-                color: match.legsWon[0] > match.legsWon[1] ? "#d4ff3a" : "#f2e8d0",
-              }}
+          {isTraining ? (
+            <div
+              className="f-mono text-xs text-muted"
+              style={{ letterSpacing: "0.18em" }}
             >
-              {match.legsWon[0]}
-            </span>
-            <span className="text-muted"> – </span>
-            <span
-              style={{
-                color: match.legsWon[1] > match.legsWon[0] ? "#d4ff3a" : "#f2e8d0",
-              }}
-            >
-              {match.legsWon[1]}
-            </span>
-          </div>
-          <div className="hidden md:block">
-            <Tag color="#6d736f">first to {match.config.legsToWin}</Tag>
-          </div>
+              ROUND{" "}
+              <span className="f-display font-black text-base ml-1 text-cream">
+                {trainingProgress}
+              </span>
+            </div>
+          ) : (
+            <>
+              <div
+                className="f-mono text-xs text-muted"
+                style={{ letterSpacing: "0.18em" }}
+              >
+                LEG{" "}
+                <span className="f-display font-black text-base ml-1 text-cream">
+                  {match.currentLeg.number}
+                </span>
+              </div>
+              <div className="f-display font-black text-xl">
+                <span
+                  style={{
+                    color: match.legsWon[0] > match.legsWon[1] ? "#d4ff3a" : "#f2e8d0",
+                  }}
+                >
+                  {match.legsWon[0]}
+                </span>
+                <span className="text-muted"> – </span>
+                <span
+                  style={{
+                    color: match.legsWon[1] > match.legsWon[0] ? "#d4ff3a" : "#f2e8d0",
+                  }}
+                >
+                  {match.legsWon[1]}
+                </span>
+              </div>
+              <div className="hidden md:block">
+                <Tag color="#6d736f">first to {match.config.legsToWin}</Tag>
+              </div>
+            </>
+          )}
         </div>
         <button
           onClick={undo}
@@ -166,44 +196,55 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
         </button>
       </div>
 
-      <div className="grid grid-cols-2">
-        <PlayerPanel
-          name={match.config.players[0]}
-          live={isX01 ? displayRemaining(match, 0) : (match.currentLeg.highlowBest[0] ?? 0)}
-          showRemaining={isX01}
-          active={p === 0}
-          legsWon={match.legsWon[0]}
-          turnDarts={p === 0 ? turnDarts : []}
-          side="left"
-          accent="#d4ff3a"
-          avg={stats[0].threeDartAvg}
-          dartsThrown={stats[0].totalDarts}
-          notStartedYet={
-            isX01 && match.config.inRule === "double" && !match.currentLeg.hasStarted[0]
-          }
-          checkoutHint={hint0}
-        />
-        <PlayerPanel
-          name={match.config.players[1]}
-          live={isX01 ? displayRemaining(match, 1) : (match.currentLeg.highlowBest[1] ?? 0)}
-          showRemaining={isX01}
-          active={p === 1}
-          legsWon={match.legsWon[1]}
-          turnDarts={p === 1 ? turnDarts : []}
-          side="right"
-          accent="#e63946"
-          avg={stats[1].threeDartAvg}
-          dartsThrown={stats[1].totalDarts}
-          notStartedYet={
-            isX01 && match.config.inRule === "double" && !match.currentLeg.hasStarted[1]
-          }
-          checkoutHint={hint1}
-        />
-      </div>
+      {isTraining ? (
+        <TrainingPanel match={match} />
+      ) : (
+        <div className="grid grid-cols-2">
+          <PlayerPanel
+            name={match.config.players[0]}
+            live={isX01 ? displayRemaining(match, 0) : (match.currentLeg.highlowBest[0] ?? 0)}
+            showRemaining={isX01}
+            active={p === 0}
+            legsWon={match.legsWon[0]}
+            turnDarts={p === 0 ? turnDarts : []}
+            side="left"
+            accent="#d4ff3a"
+            avg={stats[0].threeDartAvg}
+            dartsThrown={stats[0].totalDarts}
+            notStartedYet={
+              isX01 && match.config.inRule === "double" && !match.currentLeg.hasStarted[0]
+            }
+            checkoutHint={hint0}
+          />
+          <PlayerPanel
+            name={match.config.players[1]}
+            live={isX01 ? displayRemaining(match, 1) : (match.currentLeg.highlowBest[1] ?? 0)}
+            showRemaining={isX01}
+            active={p === 1}
+            legsWon={match.legsWon[1]}
+            turnDarts={p === 1 ? turnDarts : []}
+            side="right"
+            accent="#e63946"
+            avg={stats[1].threeDartAvg}
+            dartsThrown={stats[1].totalDarts}
+            notStartedYet={
+              isX01 && match.config.inRule === "double" && !match.currentLeg.hasStarted[1]
+            }
+            checkoutHint={hint1}
+          />
+        </div>
+      )}
 
       <div className="px-3 md:px-6 py-2.5 border-t border-border-soft bg-surface flex items-center justify-between gap-3 flex-wrap">
         <div className="flex items-center gap-2.5 flex-wrap">
-          {isX01 && needsDoubleIn ? (
+          {isTraining && trainingTarget ? (
+            <span className="f-mono text-xs text-bone">
+              Hit{" "}
+              <span className="f-display font-black text-electric">
+                {targetLabel(trainingTarget)}
+              </span>
+            </span>
+          ) : isX01 && needsDoubleIn ? (
             <>
               <Tag color="#e63946" bg="#e6394615">
                 NEEDS DOUBLE IN
@@ -223,7 +264,7 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
           )}
         </div>
         <div className="f-serif italic text-sm text-bone">
-          {match.config.players[p]} to throw
+          {isTraining ? "your throw" : `${match.config.players[p]} to throw`}
           <span className="f-mono not-italic text-xs ml-2 text-muted">
             · dart {turnDarts.length + 1}/3
           </span>

--- a/components/summary/SummaryScreen.tsx
+++ b/components/summary/SummaryScreen.tsx
@@ -6,6 +6,7 @@ import type { Match, PlayerStats } from "@/lib/types";
 import { computeStats } from "@/lib/scoring";
 import { ruleLabel } from "@/lib/format";
 import { BrandMark, Tag } from "@/components/ui/primitives";
+import { TrainingSummary } from "./TrainingSummary";
 
 interface Props {
   match: Match;
@@ -15,6 +16,12 @@ interface Props {
 }
 
 export function SummaryScreen({ match, onRestart, onNewMatch, onBackToTournament }: Props) {
+  if (match.config.mode === "training" && match.training) {
+    return (
+      <TrainingSummary match={match} onNewMatch={onNewMatch} onRestart={onRestart} />
+    );
+  }
+
   const stats = useMemo(() => computeStats(match), [match]);
   const winner = match.winner!;
   const loser = (1 - winner) as 0 | 1;

--- a/components/summary/TrainingSummary.tsx
+++ b/components/summary/TrainingSummary.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { Home, Target } from "lucide-react";
+import type { Match, TrainingState } from "@/lib/types";
+import { computeTrainingStats } from "@/lib/scoring";
+import { drillLabel, targetLabel } from "@/lib/format";
+import { BrandMark, Tag } from "@/components/ui/primitives";
+
+interface Props {
+  match: Match;
+  onNewMatch: () => void;
+  onRestart: () => void;
+}
+
+export function TrainingSummary({ match, onNewMatch, onRestart }: Props) {
+  const state = match.training!;
+  const stats = computeTrainingStats(state);
+  const durationMin =
+    match.endedAt && match.startedAt
+      ? Math.round((match.endedAt - match.startedAt) / 60000)
+      : 0;
+
+  const headline = (() => {
+    if (state.drill === "bobs27") {
+      return state.finalKind === "bust" ? "BUSTED." : "DRILL DONE.";
+    }
+    if (state.drill === "doubles") return "DRILL DONE.";
+    return "PRACTICE DONE.";
+  })();
+
+  const subline = (() => {
+    if (state.drill === "doubles") return `${stats.hits} hits across 21 targets`;
+    if (state.drill === "bobs27") {
+      if (state.finalKind === "bust") return `Busted on D${state.cursor + 1} with ${stats.finalScore ?? 0} pts`;
+      return `Final score · ${stats.finalScore ?? 0} pts`;
+    }
+    return `${stats.hits} of ${stats.attempts} checkouts`;
+  })();
+
+  return (
+    <div className="min-h-screen flex flex-col bg-ink">
+      <div className="flex items-center justify-between px-6 py-5 border-b border-border-soft">
+        <BrandMark size="sm" />
+        <Tag color="#6d736f">practice complete</Tag>
+      </div>
+      <div className="flex-1 px-6 py-10 md:py-16 max-w-5xl w-full mx-auto">
+        <div className="flex items-center gap-3 mb-4 rise">
+          <div className="h-px w-10 bg-electric" />
+          <span
+            className="f-mono text-xs uppercase text-electric"
+            style={{ letterSpacing: "0.25em" }}
+          >
+            {drillLabel(state.drill)} {durationMin > 0 && `· ${durationMin}m`}
+          </span>
+        </div>
+
+        <div className="bang mb-10">
+          <div
+            className="f-display font-black leading-[0.88]"
+            style={{
+              fontSize: "clamp(64px, 11vw, 180px)",
+              color: state.finalKind === "bust" ? "#e63946" : "#f2e8d0",
+            }}
+          >
+            {headline}
+          </div>
+          <div className="f-serif italic text-xl mt-4 text-bone">
+            {subline}
+          </div>
+        </div>
+
+        <div className="mb-10">
+          <DrillStatsCard state={state} stats={stats} />
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            onClick={onRestart}
+            className="f-display font-black text-2xl uppercase px-6 py-4 flex items-center gap-3 bg-electric text-ink"
+          >
+            <Target className="w-6 h-6" strokeWidth={2.5} /> Practice again
+          </button>
+          <button
+            onClick={onNewMatch}
+            className="f-mono text-sm uppercase px-6 py-4 border border-border text-cream flex items-center gap-2"
+            style={{ letterSpacing: "0.22em" }}
+          >
+            <Home className="w-4 h-4" /> Lobby
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DrillStatsCard({ state, stats }: { state: TrainingState; stats: ReturnType<typeof computeTrainingStats> }) {
+  return (
+    <div className="border border-border p-6" style={{ background: "#141a17" }}>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+        <MiniStat label="DARTS" value={stats.totalDarts} />
+        {state.drill === "checkout" ? (
+          <>
+            <MiniStat label="HIT" value={`${stats.hits} / ${stats.attempts}`} highlight />
+            <MiniStat label="ACCURACY" value={`${stats.accuracyPct.toFixed(0)}%`} />
+            <MiniStat label="AVG DARTS" value={(stats.avgFinishDarts ?? 0).toFixed(1)} />
+          </>
+        ) : (
+          <>
+            <MiniStat label="HITS" value={stats.hits} highlight />
+            <MiniStat label="ACCURACY" value={`${stats.accuracyPct.toFixed(0)}%`} />
+            <MiniStat label="STREAK" value={stats.longestStreak} />
+          </>
+        )}
+      </div>
+      {state.drill === "bobs27" && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+          <MiniStat label="FINAL SCORE" value={stats.finalScore ?? 0} highlight wide />
+          <MiniStat label="OUTCOME" value={state.finalKind === "bust" ? "BUST" : "COMPLETE"} accent={state.finalKind === "bust"} />
+        </div>
+      )}
+      {state.drill === "checkout" && stats.bestFinish ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+          <MiniStat label="BEST FINISH" value={stats.bestFinish} highlight wide />
+        </div>
+      ) : null}
+
+      <div className="border-t border-border-soft pt-4">
+        <div
+          className="f-mono text-[10px] uppercase text-muted mb-3"
+          style={{ letterSpacing: "0.22em" }}
+        >
+          rounds
+        </div>
+        <div className="flex gap-1.5 flex-wrap">
+          {state.rounds.map((r, i) => {
+            const ok =
+              r.outcome === "hit" ||
+              r.outcome === "checkout-success" ||
+              r.outcome === "bobs-win";
+            const bad =
+              r.outcome === "checkout-fail" ||
+              r.outcome === "bobs-bust";
+            const tcolor = ok ? "#d4ff3a" : bad ? "#e63946" : "#3a4540";
+            return (
+              <span
+                key={i}
+                className="f-mono text-[10px] px-2 py-1 border whitespace-nowrap"
+                style={{
+                  borderColor: tcolor,
+                  color: ok ? "#d4ff3a" : bad ? "#e63946" : "#d8cdaf",
+                  background: ok ? "#d4ff3a10" : bad ? "#e6394610" : "transparent",
+                }}
+              >
+                {targetLabel(r.target)}
+                {r.outcome === "checkout-success" && " ✓"}
+                {r.outcome === "checkout-fail" && " ✗"}
+                {(r.outcome === "hit" || r.outcome === "miss") && ` · ${r.hits}/${r.darts.length}`}
+                {r.scoreAfter !== undefined && ` → ${r.scoreAfter}`}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({
+  label, value, highlight, accent, muted, wide,
+}: {
+  label: string; value: string | number;
+  highlight?: boolean; accent?: boolean; muted?: boolean; wide?: boolean;
+}) {
+  return (
+    <div className="border p-2 bg-ink border-border-soft">
+      <div
+        className="f-mono text-[9px] uppercase text-muted"
+        style={{ letterSpacing: "0.2em" }}
+      >
+        {label}
+      </div>
+      <div
+        className={`f-display font-black ${wide ? "text-2xl" : "text-xl"} mt-0.5`}
+        style={{
+          color: highlight ? "#d4ff3a" : accent ? "#e63946" : muted ? "#454b47" : "#f2e8d0",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/components/training/TrainingPanel.tsx
+++ b/components/training/TrainingPanel.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import type { Dart, Match, TrainingState } from "@/lib/types";
+import {
+  trainingCurrentTarget, trainingTotalRounds, sumDarts,
+} from "@/lib/scoring";
+import { checkoutHint } from "@/lib/checkouts";
+import { drillLabel, targetLabel } from "@/lib/format";
+import { Tag } from "@/components/ui/primitives";
+
+interface Props {
+  match: Match;
+}
+
+export function TrainingPanel({ match }: Props) {
+  const state = match.training!;
+  const target = trainingCurrentTarget(state);
+  const total = trainingTotalRounds(state, match.config);
+  const turnDarts = state.currentDarts;
+
+  const currentTargetText = target ? targetLabel(target) : "—";
+  const subtitle = (() => {
+    if (state.drill === "doubles") {
+      return target?.kind === "bull" ? "Final round · BULL" : `Target · D${state.cursor + 1}`;
+    }
+    if (state.drill === "bobs27") {
+      return `Target · D${state.cursor + 1}`;
+    }
+    return `Checkout ${state.cursor + 1} of ${total}`;
+  })();
+
+  const liveScore = (() => {
+    if (state.drill === "checkout" && target?.kind === "checkout") {
+      return target.remaining - sumDarts(turnDarts);
+    }
+    if (state.drill === "bobs27") return state.score;
+    return null;
+  })();
+
+  const hint =
+    state.drill === "checkout" && target?.kind === "checkout" && liveScore !== null && liveScore > 0
+      ? checkoutHint(liveScore, "double")
+      : null;
+
+  const hits = state.rounds.reduce((a, r) => a + r.hits, 0);
+  const successCount = state.rounds.filter((r) => r.outcome === "checkout-success").length;
+
+  return (
+    <div className="relative p-3 md:p-6 border-b border-border-soft" style={{ background: "#1c2420", minHeight: 260 }}>
+      <div className="absolute top-0 left-0 right-0 h-1 bg-electric" style={{ boxShadow: "0 0 20px #d4ff3a" }} />
+
+      <div className="flex items-start justify-between mb-3 gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <Tag color="#d4ff3a">
+            <span className="w-1.5 h-1.5 rounded-full live-dot bg-electric" />
+            {drillLabel(state.drill)}
+          </Tag>
+          <span
+            className="f-mono text-[10px] uppercase text-muted"
+            style={{ letterSpacing: "0.2em" }}
+          >
+            {subtitle}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <ProgressBadge label="round" value={`${Math.min(state.cursor + 1, total)} / ${total}`} />
+          {state.drill === "doubles" && <ProgressBadge label="hits" value={`${hits}`} />}
+          {state.drill === "bobs27" && (
+            <ProgressBadge label="score" value={`${state.score}`} accent={state.score < 27 ? "#e63946" : "#d4ff3a"} />
+          )}
+          {state.drill === "checkout" && (
+            <ProgressBadge label="hit" value={`${successCount} / ${state.rounds.length || 0}`} />
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] items-end gap-4">
+        <div>
+          <div
+            className="f-mono text-[10px] uppercase text-muted mb-1"
+            style={{ letterSpacing: "0.25em" }}
+          >
+            {state.drill === "checkout" ? "checkout from" : "current target"}
+          </div>
+          <div
+            className="f-display font-black leading-none text-electric"
+            style={{
+              fontSize: "clamp(80px, 17vw, 180px)",
+              textShadow: "0 0 30px #d4ff3a55",
+            }}
+          >
+            {currentTargetText}
+          </div>
+          {hint && (
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+              <span
+                className="f-mono text-[10px] uppercase text-electric"
+                style={{ letterSpacing: "0.22em" }}
+              >
+                Suggest
+              </span>
+              <div className="flex gap-1.5">
+                {hint.map((h, i) => (
+                  <span
+                    key={i}
+                    className="f-display font-bold text-xs px-2 py-0.5 border"
+                    style={{
+                      borderColor: "#d4ff3a",
+                      background: "#d4ff3a14",
+                      color: "#d4ff3a",
+                    }}
+                  >
+                    {h}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {state.drill === "checkout" && liveScore !== null && liveScore > 0 && turnDarts.length > 0 && (
+            <div
+              className="f-mono text-xs text-bone mt-2"
+              style={{ letterSpacing: "0.1em" }}
+            >
+              {liveScore} remaining
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-3 gap-1.5 w-full md:w-[360px]">
+          {[0, 1, 2].map((i) => {
+            const d = turnDarts[i];
+            const filled = !!d;
+            return (
+              <div
+                key={i}
+                className={filled ? "dart-in" : ""}
+                style={{
+                  border: `1px solid ${
+                    filled
+                      ? d.multiplier === 3 ? "#e63946"
+                      : d.multiplier === 2 ? "#d4ff3a"
+                      : "#2a332d"
+                      : "#1f2824"
+                  }`,
+                  background: filled
+                    ? d.multiplier === 3 ? "#e6394618"
+                    : d.multiplier === 2 ? "#d4ff3a18"
+                    : "#0a0e0c"
+                    : "#0a0e0c",
+                  padding: "8px 10px",
+                }}
+              >
+                <div
+                  className="f-mono text-[9px] text-muted"
+                  style={{ letterSpacing: "0.18em" }}
+                >
+                  D{i + 1}
+                </div>
+                <div className="flex items-baseline justify-between">
+                  <span
+                    className="f-display font-black text-lg"
+                    style={{ color: filled ? "#f2e8d0" : "#454b47" }}
+                  >
+                    {filled ? d.label : "—"}
+                  </span>
+                  {filled && <span className="f-mono text-[10px] text-bone">{d.score}</span>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {state.rounds.length > 0 && (
+        <div className="mt-4 flex items-center gap-2 overflow-x-auto pb-1">
+          <span
+            className="f-mono text-[9px] uppercase text-muted shrink-0"
+            style={{ letterSpacing: "0.25em" }}
+          >
+            recent
+          </span>
+          <div className="flex gap-1.5">
+            {state.rounds.slice(-12).map((r, i) => {
+              const ok =
+                r.outcome === "hit" ||
+                r.outcome === "checkout-success" ||
+                r.outcome === "bobs-win";
+              const bad =
+                r.outcome === "checkout-fail" ||
+                r.outcome === "bobs-bust";
+              const tcolor = ok ? "#d4ff3a" : bad ? "#e63946" : "#3a4540";
+              return (
+                <span
+                  key={i}
+                  className="f-mono text-[10px] px-1.5 py-0.5 border whitespace-nowrap"
+                  style={{
+                    borderColor: tcolor,
+                    color: ok ? "#d4ff3a" : bad ? "#e63946" : "#d8cdaf",
+                    background: ok ? "#d4ff3a10" : bad ? "#e6394610" : "transparent",
+                  }}
+                >
+                  {targetLabel(r.target)}
+                  {r.outcome === "checkout-success" && " ✓"}
+                  {r.outcome === "checkout-fail" && " ✗"}
+                  {(r.outcome === "hit" || r.outcome === "miss") && ` · ${r.hits}/${r.darts.length}`}
+                  {r.scoreAfter !== undefined && ` → ${r.scoreAfter}`}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProgressBadge({ label, value, accent = "#f2e8d0" }: { label: string; value: string; accent?: string }) {
+  return (
+    <div className="text-right">
+      <div
+        className="f-mono text-[9px] uppercase text-muted"
+        style={{ letterSpacing: "0.22em" }}
+      >
+        {label}
+      </div>
+      <div
+        className="f-display font-black text-xl leading-none"
+        style={{ color: accent }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/lib/db/games.ts
+++ b/lib/db/games.ts
@@ -32,11 +32,15 @@ export async function createGame(
 ): Promise<Game> {
   const db = requireSql();
 
-  if (guestName) {
+  const isTraining = config.mode === "training";
+  if (guestName || isTraining) {
     const [p1row] = await db`SELECT display_name FROM users WHERE id = ${userId}`;
     const matchConfig = {
       ...config,
-      players: [displayName(player1Email, p1row?.display_name as string | null), guestName.trim()] as [string, string],
+      players: [
+        displayName(player1Email, p1row?.display_name as string | null),
+        isTraining ? "" : guestName!.trim(),
+      ] as [string, string],
     };
     const initialMatch = createMatch(matchConfig);
     const [row] = await db`

--- a/lib/db/history.ts
+++ b/lib/db/history.ts
@@ -1,9 +1,15 @@
 import { sql } from "@/lib/db";
-import { computeStats } from "@/lib/scoring";
+import { computeStats, computeTrainingStats } from "@/lib/scoring";
 import { computeRankings } from "@/lib/tournament";
 import { getTournament } from "@/lib/db/tournaments";
-import type { GameConfig, Match, TournamentFormat } from "@/lib/types";
+import type { GameConfig, Match, TournamentFormat, TrainingDrill } from "@/lib/types";
 import { displayName } from "@/lib/display";
+
+export interface TrainingHistorySummary {
+  drill: TrainingDrill;
+  resultLabel: string;   // e.g. "12 / 21", "447 pts", "BUSTED"
+  metricLabel: string;   // e.g. "57% accuracy", "8/10 checkouts"
+}
 
 export interface GameHistoryItem {
   id: string;
@@ -17,6 +23,8 @@ export interface GameHistoryItem {
   tonEighty: number;
   bestFinish: number;
   isGuestGame: boolean;
+  isTraining: boolean;
+  trainingSummary?: TrainingHistorySummary;
 }
 
 export interface TournamentHistoryItem {
@@ -57,6 +65,40 @@ export async function getGameHistory(
       const match = row.match_state as Match;
       if (match.winner === null) continue;
 
+      // Training session
+      if (match.config.mode === "training" && match.training) {
+        const ts = computeTrainingStats(match.training);
+        const drill = match.training.drill;
+        let resultLabel = "";
+        let metricLabel = "";
+        if (drill === "doubles") {
+          resultLabel = `${ts.hits} / 21`;
+          metricLabel = `${ts.accuracyPct.toFixed(0)}% accuracy · streak ${ts.longestStreak}`;
+        } else if (drill === "bobs27") {
+          resultLabel = match.training.finalKind === "bust" ? "BUSTED" : `${ts.finalScore ?? 0} pts`;
+          metricLabel = `${ts.hits} hits · ${ts.totalDarts} darts`;
+        } else {
+          resultLabel = `${ts.hits} / ${ts.attempts}`;
+          metricLabel = ts.bestFinish ? `best ${ts.bestFinish}` : `${ts.accuracyPct.toFixed(0)}%`;
+        }
+        items.push({
+          id: row.id as string,
+          date: (row.finished_at as Date) ?? new Date(),
+          opponent: "",
+          config: row.config as GameConfig,
+          result: "win",
+          legsWon: 0,
+          legsLost: 0,
+          threeDartAvg: 0,
+          tonEighty: 0,
+          bestFinish: ts.bestFinish ?? 0,
+          isGuestGame: true,
+          isTraining: true,
+          trainingSummary: { drill, resultLabel, metricLabel },
+        });
+        continue;
+      }
+
       const isPlayer1 = Number(row.player1_id) === userId;
       const playerIdx = isPlayer1 ? 0 : 1;
       const opponentIdx = (1 - playerIdx) as 0 | 1;
@@ -86,6 +128,7 @@ export async function getGameHistory(
         tonEighty: myStats.tonEighty,
         bestFinish: myStats.bestFinish,
         isGuestGame: row.player2_id === null,
+        isTraining: false,
       });
     } catch {
       // skip malformed records

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,11 +1,24 @@
 // lib/format.ts
-import type { MatchConfig } from "./types";
+import type { MatchConfig, TrainingDrill, TrainingTarget } from "./types";
 
 export function ruleLabel(cfg: MatchConfig): string {
+  if (cfg.mode === "training") return drillLabel(cfg.drill ?? "doubles").toUpperCase();
   if (cfg.mode !== "x01") return "HIGH-LOW";
   const i = cfg.inRule === "double" ? "DI" : "SI";
   const o = cfg.outRule === "double" ? "DO" : cfg.outRule === "master" ? "MO" : "SO";
   return `${i} / ${o}`;
+}
+
+export function drillLabel(drill: TrainingDrill): string {
+  if (drill === "doubles") return "Doubles Practice";
+  if (drill === "bobs27") return "Bobs 27";
+  return "Checkout Practice";
+}
+
+export function targetLabel(t: TrainingTarget): string {
+  if (t.kind === "bull") return "BULL";
+  if (t.kind === "double") return `D${t.n}`;
+  return `${t.remaining}`;
 }
 
 export function initials(name: string): string {

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,8 +1,10 @@
-// lib/scoring.ts — pure scoring engine for X01 and High-Low
+// lib/scoring.ts — pure scoring engine for X01, High-Low, and Training drills
 import type {
   Dart, Multiplier, Turn, Leg, Match, MatchConfig,
   ApplyOutcome, PlayerStats,
+  TrainingState, TrainingRound, TrainingTarget, TrainingStats, TrainingDrill,
 } from "./types";
+import { CHECKOUTS_DOUBLE } from "./checkouts";
 
 // ─── Dart construction ──────────────────────────────────────────────
 
@@ -30,7 +32,7 @@ export const isTriple = (d: Dart): boolean => d.multiplier === 3 && d.number > 0
 
 export function createMatch(config: MatchConfig): Match {
   const startingScore = config.mode === "x01" ? config.startingScore : 0;
-  return {
+  const base: Match = {
     config: { ...config, startingScore },
     currentLeg: makeFreshLeg(1, 0, startingScore),
     legsWon: [0, 0],
@@ -38,6 +40,27 @@ export function createMatch(config: MatchConfig): Match {
     winner: null,
     startedAt: Date.now(),
   };
+  if (config.mode === "training") {
+    base.training = createTrainingState(config);
+  }
+  return base;
+}
+
+function createTrainingState(config: MatchConfig): TrainingState {
+  const drill = config.drill ?? "doubles";
+  const state: TrainingState = {
+    drill,
+    cursor: 0,
+    rounds: [],
+    currentDarts: [],
+    score: drill === "bobs27" ? 27 : 0,
+    finished: false,
+  };
+  if (drill === "checkout") {
+    const n = Math.max(1, Math.min(50, config.scenarioCount ?? 10));
+    state.scenarios = generateCheckoutScenarios(n);
+  }
+  return state;
 }
 
 function makeFreshLeg(number: number, startingPlayer: 0 | 1, startingScore: number): Leg {
@@ -76,6 +99,7 @@ export function displayRemaining(match: Match, p: 0 | 1): number {
 
 export function applyDart(match: Match, dart: Dart): { match: Match; outcome: ApplyOutcome } {
   if (match.winner !== null) return { match, outcome: "match-over" };
+  if (match.config.mode === "training") return applyDartTraining(match, dart);
   if (match.config.mode === "highlow") return applyDartHighLow(match, dart);
   return applyDartX01(match, dart);
 }
@@ -325,10 +349,291 @@ function applyDartHighLow(match: Match, dart: Dart): { match: Match; outcome: Ap
   };
 }
 
+// ─── Training drills ───────────────────────────────────────────────
+
+export function trainingTotalRounds(state: TrainingState, config: MatchConfig): number {
+  if (state.drill === "doubles") return 21;        // D1..D20 + BULL
+  if (state.drill === "bobs27") return 20;         // D1..D20
+  return state.scenarios?.length ?? config.scenarioCount ?? 10;
+}
+
+export function trainingCurrentTarget(state: TrainingState): TrainingTarget | null {
+  if (state.finished) return null;
+  if (state.drill === "doubles") {
+    if (state.cursor < 20) return { kind: "double", n: state.cursor + 1 };
+    return { kind: "bull" };
+  }
+  if (state.drill === "bobs27") {
+    return { kind: "double", n: state.cursor + 1 };
+  }
+  // checkout
+  if (!state.scenarios || state.cursor >= state.scenarios.length) return null;
+  return { kind: "checkout", remaining: state.scenarios[state.cursor] };
+}
+
+function dartHitsDoubleTarget(dart: Dart, n: number): boolean {
+  return dart.multiplier === 2 && dart.number === n;
+}
+
+function dartHitsBull(dart: Dart): boolean {
+  return dart.multiplier === 2 && dart.number === 25;
+}
+
+function applyDartTraining(match: Match, dart: Dart): { match: Match; outcome: ApplyOutcome } {
+  if (!match.training) return { match, outcome: "match-over" };
+  if (match.training.finished) return { match, outcome: "match-over" };
+  switch (match.training.drill) {
+    case "doubles":  return applyDartDoubles(match, dart);
+    case "bobs27":   return applyDartBobs27(match, dart);
+    case "checkout": return applyDartCheckout(match, dart);
+  }
+}
+
+function withTraining(match: Match, training: TrainingState): Match {
+  return { ...match, training };
+}
+
+function pushDart(state: TrainingState, dart: Dart): TrainingState {
+  return { ...state, currentDarts: [...state.currentDarts, dart] };
+}
+
+function commitRound(state: TrainingState, round: TrainingRound): TrainingState {
+  return {
+    ...state,
+    rounds: [...state.rounds, round],
+    currentDarts: [],
+    cursor: state.cursor + 1,
+  };
+}
+
+function applyDartDoubles(match: Match, dart: Dart): { match: Match; outcome: ApplyOutcome } {
+  const t = match.training!;
+  const target = trainingCurrentTarget(t);
+  if (!target) return { match, outcome: "match-over" };
+
+  const newDarts = [...t.currentDarts, dart];
+  const turnFull = newDarts.length >= 3;
+  if (!turnFull) {
+    return { match: withTraining(match, { ...t, currentDarts: newDarts }), outcome: "dart" };
+  }
+
+  const hits = newDarts.filter((d) =>
+    target.kind === "bull" ? dartHitsBull(d) : target.kind === "double" ? dartHitsDoubleTarget(d, target.n) : false,
+  ).length;
+
+  const round: TrainingRound = {
+    target,
+    darts: newDarts,
+    hits,
+    outcome: hits > 0 ? "hit" : "miss",
+  };
+  let next = commitRound(t, round);
+
+  if (next.cursor >= 21) {
+    next = { ...next, finished: true, finalKind: "complete" };
+    return finishTraining(match, next);
+  }
+  return { match: withTraining(match, next), outcome: "turn-end" };
+}
+
+function applyDartBobs27(match: Match, dart: Dart): { match: Match; outcome: ApplyOutcome } {
+  const t = match.training!;
+  const target = trainingCurrentTarget(t);
+  if (!target || target.kind !== "double") return { match, outcome: "match-over" };
+
+  const newDarts = [...t.currentDarts, dart];
+  const turnFull = newDarts.length >= 3;
+  if (!turnFull) {
+    return { match: withTraining(match, { ...t, currentDarts: newDarts }), outcome: "dart" };
+  }
+
+  const n = target.n;
+  const hits = newDarts.filter((d) => dartHitsDoubleTarget(d, n)).length;
+  const delta = hits > 0 ? hits * 2 * n : -2 * n;
+  const newScore = t.score + delta;
+
+  const bust = newScore <= 0;
+
+  const round: TrainingRound = {
+    target,
+    darts: newDarts,
+    hits,
+    outcome: bust ? "bobs-bust" : hits > 0 ? "hit" : "miss",
+    scoreAfter: newScore,
+  };
+  let next = commitRound(t, round);
+  next = { ...next, score: newScore };
+
+  if (bust) {
+    next = { ...next, finished: true, finalKind: "bust" };
+    return finishTraining(match, next);
+  }
+  if (next.cursor >= 20) {
+    next = { ...next, finished: true, finalKind: "complete" };
+    return finishTraining(match, next);
+  }
+  return { match: withTraining(match, next), outcome: "turn-end" };
+}
+
+function applyDartCheckout(match: Match, dart: Dart): { match: Match; outcome: ApplyOutcome } {
+  const t = match.training!;
+  const target = trainingCurrentTarget(t);
+  if (!target || target.kind !== "checkout") return { match, outcome: "match-over" };
+
+  const startRemaining = target.remaining;
+  const newDarts = [...t.currentDarts, dart];
+
+  // Compute remaining after each dart, applying double-out rules locally.
+  let rem = startRemaining;
+  let success = false;
+  let bust = false;
+  for (const d of newDarts) {
+    const after = rem - d.score;
+    if (after < 0) { bust = true; break; }
+    if (after === 0) {
+      if (isDouble(d)) { success = true; rem = 0; break; }
+      bust = true; break;
+    }
+    if (after === 1) { bust = true; break; }
+    rem = after;
+  }
+
+  const turnFull = newDarts.length >= 3;
+  const finalize = success || bust || turnFull;
+  if (!finalize) {
+    return { match: withTraining(match, { ...t, currentDarts: newDarts }), outcome: "dart" };
+  }
+
+  const round: TrainingRound = {
+    target,
+    darts: newDarts,
+    hits: success ? 1 : 0,
+    outcome: success ? "checkout-success" : "checkout-fail",
+    finishDarts: success ? newDarts.length : undefined,
+  };
+  let next = commitRound(t, round);
+
+  const total = t.scenarios?.length ?? 0;
+  if (next.cursor >= total) {
+    next = { ...next, finished: true, finalKind: "complete" };
+    return finishTraining(match, next);
+  }
+  return { match: withTraining(match, next), outcome: success ? "leg-won" : "turn-end" };
+}
+
+function finishTraining(match: Match, next: TrainingState): { match: Match; outcome: ApplyOutcome } {
+  return {
+    match: { ...match, training: next, winner: 0, endedAt: Date.now() },
+    outcome: "match-won",
+  };
+}
+
+// ─── Checkout scenario generator ──────────────────────────────────
+
+const COMMON_FINISHES_SUPP = [40, 36, 32, 28, 24, 20, 16, 12, 8, 50, 41, 45, 60, 65, 80, 85];
+
+export function generateCheckoutScenarios(n: number, seed?: number): number[] {
+  // Pool: curated finishes from CHECKOUTS_DOUBLE plus common doubles & odd setups.
+  const pool = new Set<number>();
+  for (const k of Object.keys(CHECKOUTS_DOUBLE)) {
+    const v = Number(k);
+    if (v >= 41 && v <= 170) pool.add(v);
+  }
+  for (const v of COMMON_FINISHES_SUPP) pool.add(v);
+  const arr = Array.from(pool);
+
+  // Simple seeded PRNG (mulberry32) so sessions feel deterministic-ish.
+  let s = seed ?? Date.now() & 0xffffffff;
+  const rand = () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  // Fisher-Yates partial shuffle.
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr.slice(0, Math.min(n, arr.length));
+}
+
+// ─── Training stats ───────────────────────────────────────────────
+
+export function computeTrainingStats(state: TrainingState): TrainingStats {
+  const totalDarts = state.rounds.reduce((a, r) => a + r.darts.length, 0);
+  let hits = 0;
+  let attempts = state.rounds.length;
+  let longestStreak = 0;
+  let currentStreak = 0;
+  let bestFinish = 0;
+  let finishDartsTotal = 0;
+  let successCount = 0;
+
+  if (state.drill === "checkout") {
+    for (const r of state.rounds) {
+      const ok = r.outcome === "checkout-success";
+      if (ok) {
+        hits++;
+        successCount++;
+        finishDartsTotal += r.finishDarts ?? 0;
+        if (r.target.kind === "checkout" && r.target.remaining > bestFinish) {
+          bestFinish = r.target.remaining;
+        }
+        currentStreak++;
+        if (currentStreak > longestStreak) longestStreak = currentStreak;
+      } else {
+        currentStreak = 0;
+      }
+    }
+  } else {
+    for (const r of state.rounds) {
+      hits += r.hits;
+      if (r.hits > 0) {
+        currentStreak++;
+        if (currentStreak > longestStreak) longestStreak = currentStreak;
+      } else {
+        currentStreak = 0;
+      }
+    }
+  }
+
+  const stats: TrainingStats = {
+    drill: state.drill,
+    totalDarts,
+    hits,
+    attempts,
+    accuracyPct:
+      state.drill === "checkout"
+        ? attempts > 0 ? (hits / attempts) * 100 : 0
+        : totalDarts > 0 ? (hits / totalDarts) * 100 : 0,
+    longestStreak,
+    finalKind: state.finalKind,
+  };
+  if (state.drill === "bobs27") stats.finalScore = state.score;
+  if (state.drill === "checkout") {
+    stats.avgFinishDarts = successCount > 0 ? finishDartsTotal / successCount : 0;
+    stats.bestFinish = bestFinish;
+  }
+  return stats;
+}
+
 // ─── Undo ─────────────────────────────────────────────────────────
 
 export function undoLastDart(match: Match): Match {
   if (match.winner !== null) return match;
+  if (match.config.mode === "training" && match.training) {
+    if (match.training.currentDarts.length === 0) return match;
+    return {
+      ...match,
+      training: {
+        ...match.training,
+        currentDarts: match.training.currentDarts.slice(0, -1),
+      },
+    };
+  }
   const leg = match.currentLeg;
   if (leg.currentTurnDarts.length > 0) {
     return {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,17 +80,63 @@ export interface CompletedLeg {
   startingPlayer: 0 | 1;
 }
 
-export type GameMode = "x01" | "highlow";
+export type GameMode = "x01" | "highlow" | "training";
 export type InRule = "straight" | "double";
 export type OutRule = "straight" | "double" | "master";
+
+export type TrainingDrill = "doubles" | "bobs27" | "checkout";
+
+export type TrainingTarget =
+  | { kind: "double"; n: number }
+  | { kind: "bull" }
+  | { kind: "checkout"; remaining: number };
+
+export type TrainingRoundOutcome =
+  | "hit"
+  | "miss"
+  | "checkout-success"
+  | "checkout-fail"
+  | "bobs-bust"
+  | "bobs-win";
+
+export interface TrainingRound {
+  target: TrainingTarget;
+  darts: Dart[];
+  hits: number;
+  outcome: TrainingRoundOutcome;
+  /** Bobs 27: running score after this round */
+  scoreAfter?: number;
+  /** Checkout: darts used to finish (if outcome === "checkout-success") */
+  finishDarts?: number;
+}
+
+export interface TrainingState {
+  drill: TrainingDrill;
+  /**
+   * Doubles + Bobs: 0..19 → D(n+1); Doubles 20 → BULL.
+   * Checkout: index into scenarios[].
+   */
+  cursor: number;
+  rounds: TrainingRound[];
+  currentDarts: Dart[];
+  /** Bobs 27 running score (start 27); unused for other drills */
+  score: number;
+  /** Checkout: pre-generated remaining values for each scenario */
+  scenarios?: number[];
+  finished: boolean;
+  finalKind?: "complete" | "bust" | "win";
+}
 
 export interface MatchConfig {
   players: [string, string];
   legsToWin: number;
   mode: GameMode;
-  startingScore: number; // 0 for highlow
+  startingScore: number; // 0 for highlow / training
   inRule?: InRule;
   outRule?: OutRule;
+  drill?: TrainingDrill;
+  /** Checkout drill: number of scenarios (default 10) */
+  scenarioCount?: number;
 }
 
 export interface Match {
@@ -101,6 +147,7 @@ export interface Match {
   winner: 0 | 1 | null;
   startedAt: number;
   endedAt?: number;
+  training?: TrainingState;
 }
 
 export type ApplyOutcome =
@@ -117,10 +164,12 @@ export type GameStatus = "waiting" | "active" | "finished";
 
 export interface GameConfig {
   mode: GameMode;
-  startingScore: number; // 0 for highlow
+  startingScore: number; // 0 for highlow / training
   legsToWin: number;
   inRule?: InRule;
   outRule?: OutRule;
+  drill?: TrainingDrill;
+  scenarioCount?: number;
 }
 
 export interface Game {
@@ -182,6 +231,19 @@ export interface TournamentMatch {
 }
 
 // ─── Stats ────────────────────────────────────────────────────────────────────
+
+export interface TrainingStats {
+  drill: TrainingDrill;
+  totalDarts: number;
+  hits: number;          // valid hits on target (Doubles, Bobs); successful checkouts (Checkout)
+  attempts: number;      // total rounds / scenarios attempted
+  accuracyPct: number;   // hits / totalDarts * 100 for Doubles/Bobs; hits/attempts*100 for Checkout
+  longestStreak: number; // consecutive rounds with at least one hit
+  finalScore?: number;   // Bobs 27 final
+  avgFinishDarts?: number; // Checkout: avg darts per successful scenario
+  bestFinish?: number;   // Checkout: highest scenario successfully checked out
+  finalKind?: "complete" | "bust" | "win";
+}
 
 export interface PlayerStats {
   threeDartAvg: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3139,6 +3139,111 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.4.tgz",
+      "integrity": "sha512-wBEMBs+np+R5ozN1F8Y8d/Dycns2COhRnkxRc+rvnbXke5uZBHkUGFgWxfTXn5rx7OLijuUhyfB+gC/ap58dDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.4.tgz",
+      "integrity": "sha512-7sgf5rM7Z81V9w48F02Zz6DgEJulavC0jadab4ZsJ+K2sxMNK0/BtF8J8J3CxnsJN3DGcIdC260wEKssKTukUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.4.tgz",
+      "integrity": "sha512-JaZlIMNaJenfd55kjaLWMfok+vWBlcRxqnRoZrhFQrhM1uAehP3R0+Aoe+bZOogqlZvAz53nY/k3ZyuKDtT2zQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.4.tgz",
+      "integrity": "sha512-7EBBjNoyTO2ipMDgCiORpwwOf5tIueFntKjcN3NK+GAQD7OzFJe84p7a2eQUeWdpzZvhVXuAtIen8QcH71ZCOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.4.tgz",
+      "integrity": "sha512-0578bLRVDJOh+LdIoKvgNDz77+Bd85c5JrFgnlbI1SM3WmEQvsjxTA8ATu9Z9FCiIS/AliVAW2DV/BDwpXbtiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.4.tgz",
+      "integrity": "sha512-JgFCiV4libQavwII+kncMCl30st0JVxpPOtzWcAI2jtum4HjYaclobKhj+JsRu5tFqMtA5CJIa0MvYyuu9xjjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.4.tgz",
+      "integrity": "sha512-xxsJy9wzq7FR5SqPCUqdgSXiNXrMuidgckBa8nH9HtjjxsilgcN6VgXF6tZ3uEWuVEadotQJI8/9EQ6guTC4Yw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/tests/scoring.test.ts
+++ b/tests/scoring.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   applyDart, createMatch, displayRemaining, makeDart,
   undoLastDart, computeStats, sumDarts,
+  computeTrainingStats, generateCheckoutScenarios,
 } from "../lib/scoring";
-import type { Match } from "../lib/types";
+import type { Match, MatchConfig } from "../lib/types";
 
 const T = (n: number) => makeDart(3, n);
 const D = (n: number) => makeDart(2, n);
@@ -260,5 +261,189 @@ describe("Stats sanity", () => {
     expect(stats[0].totalDarts).toBe(3);
     // 100 total / 3 darts * 3 = 100
     expect(stats[0].threeDartAvg).toBe(100);
+  });
+});
+
+// ─── Training mode ────────────────────────────────────────────────
+
+const trainingBase = (drill: "doubles" | "bobs27" | "checkout", extras: Partial<MatchConfig> = {}): MatchConfig => ({
+  players: ["You", ""],
+  legsToWin: 1,
+  mode: "training",
+  startingScore: 0,
+  drill,
+  ...extras,
+});
+
+describe("Training: Doubles Practice", () => {
+  it("starts at D1 and advances cursor every 3 darts", () => {
+    let m = createMatch(trainingBase("doubles"));
+    expect(m.training?.cursor).toBe(0);
+    m = throwMany(m, [D(1), MISS, MISS]);
+    expect(m.training?.cursor).toBe(1);
+    expect(m.training?.rounds).toHaveLength(1);
+    expect(m.training?.rounds[0].hits).toBe(1);
+    expect(m.training?.rounds[0].outcome).toBe("hit");
+  });
+
+  it("only counts hits matching the current target", () => {
+    let m = createMatch(trainingBase("doubles"));
+    // cursor=0 → target D1; D5 should NOT count
+    m = throwMany(m, [D(5), D(5), D(5)]);
+    expect(m.training?.rounds[0].hits).toBe(0);
+    expect(m.training?.rounds[0].outcome).toBe("miss");
+  });
+
+  it("advances regardless of hit/miss", () => {
+    let m = createMatch(trainingBase("doubles"));
+    m = throwMany(m, [MISS, MISS, MISS]);
+    expect(m.training?.cursor).toBe(1);
+    m = throwMany(m, [MISS, MISS, MISS]);
+    expect(m.training?.cursor).toBe(2);
+  });
+
+  it("BULL is the final target and finishes the drill", () => {
+    let m = createMatch(trainingBase("doubles"));
+    // Skip through D1..D20 with all misses (20 rounds × 3 darts).
+    for (let i = 0; i < 20; i++) {
+      m = throwMany(m, [MISS, MISS, MISS]);
+    }
+    expect(m.training?.cursor).toBe(20);
+    expect(m.training?.finished).toBe(false);
+    // BULL round
+    m = throwMany(m, [BULL, MISS, MISS]);
+    expect(m.training?.cursor).toBe(21);
+    expect(m.training?.finished).toBe(true);
+    expect(m.training?.finalKind).toBe("complete");
+    expect(m.winner).toBe(0);
+    // BULL hit counted
+    expect(m.training?.rounds[20].hits).toBe(1);
+  });
+});
+
+describe("Training: Bobs 27", () => {
+  it("starts at score 27 and gains 2*n per hit", () => {
+    let m = createMatch(trainingBase("bobs27"));
+    expect(m.training?.score).toBe(27);
+    // D1 round: 1 hit = +2
+    m = throwMany(m, [D(1), MISS, MISS]);
+    expect(m.training?.score).toBe(29);
+    expect(m.training?.rounds[0].scoreAfter).toBe(29);
+  });
+
+  it("loses 2*n when all 3 darts miss", () => {
+    let m = createMatch(trainingBase("bobs27"));
+    m = throwMany(m, [MISS, MISS, MISS]); // D1 missed → -2
+    expect(m.training?.score).toBe(25);
+  });
+
+  it("busts when score drops to or below 0", () => {
+    let m = createMatch(trainingBase("bobs27"));
+    // 27 - 2 - 4 - 6 - 8 - 10 = -3 by D5 round (missed)
+    m = throwMany(m, [MISS, MISS, MISS]); // D1 → 25
+    m = throwMany(m, [MISS, MISS, MISS]); // D2 → 21
+    m = throwMany(m, [MISS, MISS, MISS]); // D3 → 15
+    m = throwMany(m, [MISS, MISS, MISS]); // D4 → 7
+    m = throwMany(m, [MISS, MISS, MISS]); // D5 → -3 BUST
+    expect(m.training?.finished).toBe(true);
+    expect(m.training?.finalKind).toBe("bust");
+    expect(m.winner).toBe(0);
+  });
+
+  it("completes after D20 round", () => {
+    let m = createMatch(trainingBase("bobs27"));
+    // Hit each double once → +2*n per round, plenty to stay positive
+    for (let n = 1; n <= 20; n++) {
+      m = throwMany(m, [D(n), MISS, MISS]);
+    }
+    expect(m.training?.finished).toBe(true);
+    expect(m.training?.finalKind).toBe("complete");
+    // 27 + 2*sum(1..20) = 27 + 420 = 447
+    expect(m.training?.score).toBe(447);
+  });
+});
+
+describe("Training: Checkout Practice", () => {
+  it("succeeds on a 1-dart double-out finish", () => {
+    let m = createMatch(trainingBase("checkout", { scenarioCount: 3 }));
+    // Force a known scenario: replace scenarios with [40, 32, 50]
+    m = { ...m, training: { ...m.training!, scenarios: [40, 32, 50] } };
+    m = throwMany(m, [D(20)]); // 40 - 40 = 0 on a double → success after 1 dart
+    expect(m.training?.cursor).toBe(1);
+    expect(m.training?.rounds[0].outcome).toBe("checkout-success");
+    expect(m.training?.rounds[0].finishDarts).toBe(1);
+  });
+
+  it("busts when landing on 1 (impossible double-out)", () => {
+    let m = createMatch(trainingBase("checkout", { scenarioCount: 1 }));
+    m = { ...m, training: { ...m.training!, scenarios: [40] } };
+    // 40 - 39 = 1 → bust
+    m = throwMany(m, [T(13)]); // T13 = 39
+    expect(m.training?.cursor).toBe(1);
+    expect(m.training?.rounds[0].outcome).toBe("checkout-fail");
+    expect(m.training?.finished).toBe(true);
+  });
+
+  it("busts when overshooting", () => {
+    let m = createMatch(trainingBase("checkout", { scenarioCount: 1 }));
+    m = { ...m, training: { ...m.training!, scenarios: [40] } };
+    // 40 → S20 (20 left) → S20 (0 left, but not double) → bust
+    m = throwMany(m, [S(20), S(20)]);
+    // Lands on 0 without double = bust → fail, drill ends
+    expect(m.training?.rounds[0].outcome).toBe("checkout-fail");
+  });
+
+  it("auto-advances after 3 darts without finish", () => {
+    let m = createMatch(trainingBase("checkout", { scenarioCount: 2 }));
+    m = { ...m, training: { ...m.training!, scenarios: [60, 40] } };
+    m = throwMany(m, [S(10), S(10), S(10)]); // 60 → 50 → 40 → 30, no finish
+    expect(m.training?.cursor).toBe(1);
+    expect(m.training?.rounds[0].outcome).toBe("checkout-fail");
+  });
+
+  it("finishes after the last scenario", () => {
+    let m = createMatch(trainingBase("checkout", { scenarioCount: 2 }));
+    m = { ...m, training: { ...m.training!, scenarios: [40, 32] } };
+    m = throwMany(m, [D(20)]); // scenario 1 success
+    m = throwMany(m, [D(16)]); // scenario 2 success
+    expect(m.training?.finished).toBe(true);
+    expect(m.winner).toBe(0);
+    const stats = computeTrainingStats(m.training!);
+    expect(stats.hits).toBe(2);
+    expect(stats.attempts).toBe(2);
+    expect(stats.avgFinishDarts).toBe(1);
+  });
+});
+
+describe("Training: undo and helpers", () => {
+  it("undoes only within the current turn", () => {
+    let m = createMatch(trainingBase("doubles"));
+    m = throwMany(m, [D(1), MISS]);
+    expect(m.training?.currentDarts).toHaveLength(2);
+    m = undoLastDart(m);
+    expect(m.training?.currentDarts).toHaveLength(1);
+    m = undoLastDart(m);
+    expect(m.training?.currentDarts).toHaveLength(0);
+    // No-op when nothing to undo
+    const before = m;
+    m = undoLastDart(m);
+    expect(m).toBe(before);
+  });
+
+  it("computeStats returns zeros for training mode", () => {
+    let m = createMatch(trainingBase("doubles"));
+    m = throwMany(m, [D(1), D(1), D(1)]);
+    const [s0] = computeStats(m);
+    expect(s0.totalDarts).toBe(0);
+    expect(s0.threeDartAvg).toBe(0);
+  });
+
+  it("generateCheckoutScenarios returns N values in checkout range", () => {
+    const scen = generateCheckoutScenarios(8, 42);
+    expect(scen).toHaveLength(8);
+    for (const v of scen) {
+      expect(v).toBeGreaterThanOrEqual(2);
+      expect(v).toBeLessThanOrEqual(170);
+    }
   });
 });


### PR DESCRIPTION
## Summary

All checks green: **60/60 tests pass**, **zero type errors**, **`next build` succeeds**.

Summary of what landed:

**Engine (`lib/scoring.ts`, `lib/types.ts`)**
- Added `mode: "training"` and three drills: `doubles` / `bobs27` / `checkout`
- New `TrainingState` lives on `Match`; pure dispatcher `applyDartTraining` with per-drill handlers
- `generateCheckoutScenarios` (seeded, draws from `CHECKOUTS_DOUBLE`) + `computeTrainingStats`
- Undo limited to in-turn for training (no cross-round rollback)
- 16 new tests covering each drill's commit/advance/end + bust + undo

**UI**
- `Practice` button on lobby → `CreateTrainingForm` modal (drill picker + scenario count for Checkout)
- `TrainingPanel` replaces the two-`PlayerPanel` grid when `mode === "training"`: shows current target big, checkout hint for Checkout drill, recent rounds strip
- `MatchScreen` adapted: header shows ROUND x/y, status bar shows "Hit D7", overlays disabled
- `TrainingSummary` replaces the W/L summary with drill-specific stats + per-round visualisation

**Persistence & history**
- Reuses existing `games` JSONB (no migration). `createGame` now accepts training mode without `guestName`.
- `getGameHistory` tags training rows with a `trainingSummary` (e.g. "12 / 21 · 57% accuracy")
- New "Practice" section on `/history`; per-game detail route redirects training back to the list
- "Your games" labels in-progress training sessions distinctly

To try it locally: `docker compose up -d --build app && docker compose exec app node scripts/migrate.mjs` (no new migrations to apply, but the script is idempotent), then visit `/lobby` → **Practice**.

## Commits

- `905bbf1` feat: Add targeted training mode for darts
- `316a3d4` chore(release): 1.5.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Training Mode — Solo Practice Drills

## Context

The user wants a solo practice mode where they play alone against a chosen drill, tracking specific dart-targeting skills rather than a normal X01 / High-Low match. The first version ships **three drills** (chosen via clarification):

- **Doubles Practice** — hit D1 → D2 → … → D20 → BULL in order, 3 darts per target
- **Bobs 27** — start at 27, target D1…D20 in order, +2×n per hit, −2×n if all 3 darts miss, bust at ≤0, win at 1437
- **Checkout Practice** — random checkout scenarios (e.g. 170, 161, 121…), 3 darts to finish (must double-out)

Sessions **persist to history** so the user can track progress over time.

The challenge: the existing engine and UI are deeply two-player, score-decreasing. Training is one-player with drill-specific state (target index, scenario list, Bobs score). Plan keeps the existing `games` table + `Match` envelope, but adds a parallel `TrainingState` slot and a `mode === "training"` branch in the engine and UI.

---

## Approach (high level)

- **Reuse the `games` table** — store training as JSONB in `match_state`, no migration. Use the existing `guestName` solo-creation path with an empty guest name (player 2 slot is unused).
- **Add `mode: "training"`** to the engine, with a new `applyDartTraining` dispatcher that branches per `drillType`.
- **New `TrainingState` field on `Match`** — top-level optional, holds drill-specific state. Don't overload `Leg`.
- **New `TrainingPanel` UI** — single panel replacing the two-`PlayerPanel` grid; reuses the existing `Keypad`, toast, and overlay primitives.
- **Add a "Practice" lobby button** + `CreateTrainingForm` modal.
- **Extend `getGameHistory`** to surface training sessions with a drill-specific summary line.

---

## Files to modify / create

### 1. Types — `lib/types.ts`

Extend `GameMode` and add training types:

```ts
export type GameMode = "x01" | "highlow" | "training";
export type TrainingDrill = "doubles" | "bobs27" | "checkout";

export interface TrainingRound {
  // Per round / target / scenario
  target:
    | { kind: "double"; n: number }      // D1..D20
    | { kind: "bull" }                    // 50
    | { kind: "checkout"; remaining: number };
  darts: Dart[];                          // up to 3
  hits: number;                           // valid hits on target this round
  outcome: "hit" | "miss" | "checkout-success" | "checkout-fail" | "bobs-bust" | "bobs-win";
  scoreAfter?: number;                    // Bobs 27 only
}

export interface TrainingState {
  drill: TrainingDrill;
  // Doubles + Bobs: 0..19 → D(n+1); 20 → BULL (doubles only)
  // Checkout: index into scenarios[]
  cursor: number;
  rounds: TrainingRound[];                // committed history
  currentDarts: Dart[];                   // in-progress turn
  score: number;                          // Bobs 27 running total (start 27)
  scenarios?: number[];                   // Checkout: pre-generated remainings
  finished: boolean;
  finalKind?: "complete" | "bust" | "win";
}

export interface MatchConfig {
  // ...existing fields...
  drill?: TrainingDrill;
  scenarioCount?: number;                 // Checkout drill (default 10)
}

export interface GameConfig {
  // ...existing fields...
  drill?: TrainingDrill;
  scenarioCount?: number;
}

export interface Match {
  // ...existing fields...
  training?: TrainingState;
}
```

`startingScore`, `inRule`, `outRule`, `legsToWin` are unused for training — set them to safe defaults (`0`, `undefined`, `undefined`, `1`).

### 2. Engine — `lib/scoring.ts`

- `createMatch`: when `config.mode === "training"`, attach an initial `TrainingState` (cursor=0, rounds=[], currentDarts=[], score=27 for Bobs, scenarios=[…] for Checkout via a new `generateCheckoutScenarios(n)` helper).
- `applyDart`: dispatch `mode === "training"` → `applyDartTraining(match, dart)`.
- `applyDartTraining`: dispatch on `match.training.drill` → `applyDartDoubles`, `applyDartBobs27`, `applyDartCheckout`.
- Each sub-handler:
  1. Push dart to `training.currentDarts`.
  2. On 3rd dart (or instant-finish for Doubles BULL / Checkout success): commit a `TrainingRound`, advance `cursor`, update `score` / `scenarios`.
  3. When the drill ends (last target reached, Bobs bust/win, all scenarios consumed): set `match.winner = 0`, `training.finished = true`, `endedAt`, and pick `finalKind`.
- `displayRemaining`: return 0 when training (already returns 0 for non-X01).
- `undoLastDart`: for training, undo only within `training.currentDarts` (no cross-round undo in v1 — Bobs score changes make multi-round undo error-prone).
- `computeStats`: bypass for training (return zeros) — training has its own stats computed by a new `computeTrainingStats(state)` helper that returns `{ hitsTotal, attemptsTotal, accuracyPct, avgDartsPerHit, longestStreak, finalScore, scenariosWon, ... }`.

**Drill-specific rules:**

- **Doubles** — target = `cursor < 20 ? D(cursor+1) : BULL`. Counts as hit if `dart.multiplier === 2 && dart.number === cursor+1` OR (cursor=20 and `dart.multiplier===2 && dart.number===25`). Always advance after 3 darts. Drill ends after BULL round (cursor=20) commits.
- **Bobs 27** — target = `D(cursor+1)`. Round score change = `hits * 2 * (cursor+1)` if hits > 0 else `-2 * (cursor+1)`. Apply after 3 darts. Bust if `score <= 0`. Win check after D20: any `score > 0` is "complete"; `score >= 1437` is "win" (theoretical max). Drill ends at cursor=20 or bust.
- **Checkout** — current scenario = `scenarios[cursor]`. Treat as a mini X01 leg with `outRule: "double"`. Use `checkoutHint(remaining, "double")` from `lib/checkouts.ts` for hint display in UI. Reuse the existing X01 bust/win logic locally inside `applyDartCheckout` (track running remaining inside the handler — no need to mutate `Leg.remaining`). Each scenario auto-ends on win, bust, or 3 darts. Advance cursor; finish when all consumed.

**`generateCheckoutScenarios(n: number): number[]`** — pick `n` values from a pool weighted toward common checkouts. Pool ideas: include all curated finishes in `CHECKOUTS_DOUBLE` between 41–170, plus common doubles (40, 32, 36…). Use a seeded shuffle so a session feels intentional.

### 3. Tests — `tests/scoring.test.ts`

Add a new `describe("training mode", ...)` block. At least:

- Doubles: throwing D5 advances cursor from D1 to D2 only if cursor=4? (no — Doubles advances every round regardless of hit). Verify cursor advances on 3-dart commit, hits counted only when label matches target. Verify drill ends after BULL round.
- Bobs 27: hit D1 once → score 29 (27+2). Miss D1 entirely → 25. Bust if score ≤ 0 (e.g. cursor=20, all miss, 27→…→bust). Verify cursor advances and `finalKind` set correctly.
- Checkout: scenario remaining=40, throw D20 → success, cursor advances. Scenario remaining=40, throw S20+D10 → success after 2 darts, advances. Scenario remaining=40, throw S1×3 → fail (bust on landing 1), advance. Drill finishes after `scenarioCount` scenarios.
- Undo: removes last dart from `currentDarts`; no-op if `currentDarts.length === 0`.

### 4. Lobby — `components/lobby/LobbyPage.tsx` + new `CreateTrainingForm.tsx`

- Add a third button next to "Create game" / "Tournament": **"Practice"** (using a `Target` icon from lucide-react). Opens `<CreateTrainingForm />`.
- New file `components/lobby/CreateTrainingForm.tsx` — modal with:
  - Drill picker (3 cards using the same `ModeCard` pattern from `CreateGameForm`)
  - For Checkout drill: scenario count selector (5 / 10 / 20)
  - Submit → `POST /api/games` with `{ mode: "training", drill, scenarioCount, startingScore: 0, legsToWin: 1, guestName: "" }` (force solo-creation path).
  - Redirect to `/match/{game.id}` on success.

Copy the visual style from `CreateGameForm.tsx` (electric green CTA, ModeCard, OptionButton).

### 5. API + DB — `app/api/games/route.ts` + `lib/db/games.ts`

- `app/api/games/route.ts`: no change in shape — body already accepts `GameConfig & { guestName? }`. Just ensure it doesn't reject `mode === "training"`.
- `lib/db/games.ts` `createGame`: when `mode === "training"`, take the `guestName` branch but with `players: [<userDisplayName>, ""]`. The existing branch works; just need to either pass `guestName=""` (and tweak the check to allow empty for training mode) **OR** add a small explicit branch:

```ts
if (config.mode === "training") {
  // identical to guest branch, but players[1] = "" and no guestName required
}
```

Cleanest: add a tiny `isTraining = config.mode === "training"` shortcut at top of `createGame` and skip the guest-name requirement for it.

### 6. Match UI — `components/match/MatchScreen.tsx` + new `components/training/TrainingPanel.tsx`

- `MatchScreen`: detect `match.config.mode === "training"`. When training:
  - Skip the two-`PlayerPanel` grid; render `<TrainingPanel match={match} turnDarts={turnDarts} />` full-width.
  - Skip `displayRemaining`, `checkoutHint` calls (handled inside the panel for the Checkout drill).
  - Adapt the bottom status bar: show drill name + current target + drill-specific status (e.g. "Bobs 27 · target D7 · score 47").
  - Adapt the leg overlay: replace "GAME SHOT" with drill-specific celebration on completion (e.g. "TON-EIGHTY!" no, rather: "DRILL COMPLETE", "BUSTED", "CHECKOUT!" per-scenario).
  - Per-scenario flash for Checkout drill (mini overlay after each successful checkout).
- New `components/training/TrainingPanel.tsx`:
  - Header: drill name + progress (e.g. "12 / 21" for doubles, "scenario 3 / 10" for checkout, "score 47 · D7" for Bobs).
  - Big current-target display (D7 / BULL / "Checkout 121") with `checkoutHint` shown for Checkout drill (reuses `checkoutHint` from `lib/checkouts.ts`).
  - Current 3-dart turn slots (reuse the small dart-slot styling from `PlayerPanel`).
  - Mini history strip showing prior rounds (compact: target + hits, e.g. "D5 · 1/3", "121 ✓").

The Keypad needs no changes.

### 7. MatchClient — `app/(app)/match/[id]/MatchClient.tsx`

- No big change. Polling/persistence already works because everything is JSONB. The "spectator" code path won't be reached for training (no second player). Verify the join-screen gate doesn't block solo training (status='active' on creation should skip it).
- One small thing: when training finishes, `match.winner = 0` triggers the existing `onFinish` flow → routes to `SummaryScreen`. Need to handle that next.

### 8. Summary — `components/summary/SummaryScreen.tsx`

Detect `match.config.mode === "training"` and render a `<TrainingSummary match={match} />` instead of the two-player stats panel. Show:
- Drill name + final outcome banner ("DRILL COMPLETE" / "BUSTED" / final score)
- Drill-specific stats from `computeTrainingStats(match.training)`:
  - Doubles: hits/21, accuracy %, longest streak
  - Bobs 27: final score, hits-by-target table
  - Checkout: success rate (e.g. 6/10), avg darts per checkout
- "Back to lobby" button.

### 9. History — `lib/db/history.ts` + `components/history/HistoryPage.tsx`

- `GameHistoryItem`: add `isTraining: boolean` and `trainingSummary?: { drill: TrainingDrill; resultLabel: string; metric: string }`.
- `getGameHistory`: when iterating rows, detect `match.config.mode === "training"` and populate `trainingSummary` instead of the W/L fields.
- `HistoryPage`: render training rows distinctly — small `Tag` showing drill name (e.g. "DOUBLES PRACTICE"), result label (e.g. "12 / 21"), no opponent column.
- The "Your games" lobby section (`OpenGames`) — label in-progress training rows with the drill name instead of opponent name. Update `components/lobby/OpenGames.tsx` to detect `config.mode === "training"`.

### 10. Format helper — `lib/format.ts`

Add a `drillLabel(drill: TrainingDrill): string` helper for consistent display ("Doubles Practice" / "Bobs 27" / "Checkout Practice").

---

## Critical files reference

| File | What changes |
| --- | --- |
| `lib/types.ts:83-124` | Extend `GameMode`, add `TrainingDrill`, `TrainingState`, `TrainingRound`; extend `MatchConfig`/`GameConfig`/`Match` |
| `lib/scoring.ts:31-41` | `createMatch` adds `training` state for training mode |
| `lib/scoring.ts:77-81` | `applyDart` dispatches to `applyDartTraining` |
| `lib/scoring.ts` (new) | `applyDartTraining`, `applyDartDoubles`, `applyDartBobs27`, `applyDartCheckout`, `generateCheckoutScenarios`, `computeTrainingStats` |
| `lib/scoring.ts:330-356` | `undoLastDart` adds training branch (in-turn undo only) |
| `lib/scoring.ts:360-402` | `computeStats` returns zeros for training |
| `lib/checkouts.ts:91-111` | **Reused as-is** by Checkout drill for hints + finish detection (no changes) |
| `lib/db/games.ts:27-64` | `createGame` allows `mode === "training"` solo-create without `guestName` |
| `lib/db/history.ts:33-95` | `getGameHistory` surfaces training rows with `trainingSummary` |
| `app/api/games/route.ts` | Body validation accepts `mode === "training"` |
| `components/lobby/LobbyPage.tsx:84-100` | Add "Practice" button → opens new modal |
| `components/lobby/CreateTrainingForm.tsx` (new) | Drill picker modal |
| `components/lobby/OpenGames.tsx` | Label in-progress training sessions distinctly |
| `components/match/MatchScreen.tsx:31-292` | Mode-aware: training → render `TrainingPanel`; drill overlays |
| `components/training/TrainingPanel.tsx` (new) | Solo single-panel display |
| `components/summary/SummaryScreen.tsx` | Mode-aware: training → render `TrainingSummary` |
| `components/summary/TrainingSummary.tsx` (new) | Drill-specific final stats |
| `components/history/HistoryPage.tsx` | Render training rows distinctly |
| `lib/format.ts` | Add `drillLabel` helper |
| `tests/scoring.test.ts` | New `describe("training mode", ...)` block — at least 8 tests covering each drill's commit/advance/end conditions + undo |

**Reuses (no changes):**
- `components/match/Keypad.tsx` — keypad input is mode-agnostic.
- `components/match/PlayerPanel.tsx` — not used in training; reused for X01 / HighLow.
- `lib/checkouts.ts` — used by Checkout drill for hint + bust/win detection.
- `app/(app)/match/[id]/page.tsx` + `MatchClient.tsx` — polling/persistence already JSONB-based.
- `games` table schema — no migration needed.

---

## Out of scope (v1)

- Cross-round undo for Bobs (would need to roll back `score` carefully).
- Sharing training results / leaderboards.
- Custom checkout pools or user-specified targets.
- Pause / resume across devices (in-progress training appears in "Your games" but the rejoin flow is untested for solo).

---

## Verification

1. **Unit tests** — `npm test` should pass all 24 existing X01/HighLow tests + the new training tests (target ~8–12 new tests).
2. **Type check** — `npx tsc --noEmit` zero errors.
3. **Build** — `npm run build` succeeds.
4. **End-to-end manual** (Docker):
   - `docker compose up -d --build app`
   - Visit `/lobby` → click **Practice** → pick **Doubles Practice** → tap through 21 targets, verify:
     - Cursor advances after every 3 darts regardless of hit.
     - Hits-on-target are counted correctly (only `D{cursor+1}` or BULL on cursor=20).
     - Final summary shows hits/21 + accuracy.
   - Repeat for **Bobs 27**: verify score updates by `±2×n`, bust at ≤0 ends drill with "BUSTED" banner, win at 1437 unlikely but D20 with score>0 → "DRILL COMPLETE".
   - Repeat for **Checkout Practice** with 5 scenarios: verify checkout hint shows correctly, hitting the finish advances scenario, busting (e.g. landing on 1) advances scenario, summary shows X/5 success rate.
   - Verify `/history` shows the three completed training sessions with drill-specific summary lines.
   - Refresh mid-session → confirm session resumes from JSONB state.
5. **Visual** — confirm the training panel preserves the OCHE brand personality (electric green accents, condensed display type, italic serif accents). The user reviews by playing — visual polish matters.

</details>

## Original Request

**Add targeted training mode for darts**

> I’d like to add a training mode where a player plays a single match with different match types to learn hitting specific darts on the board. You want to do the nipsumy with foot? Yeah. Oh

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)