### PR TITLE
Rerun releases with same version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,16 @@ jobs:
           TAG="${{ inputs.tag }}"
           echo "NEW_VERSION=${TAG#v}" >> "$GITHUB_ENV"
 
-      # No release? Bail cleanly. semantic-release skips on chore/docs-only diffs.
+      # Manual dispatch with empty tag and no new version warranted → redeploy
+      # the version currently in package.json (i.e. the latest released version).
+      - name: Fallback to package.json version (manual rerun)
+        if: env.NEW_VERSION == '' && github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "No new release from semantic-release. Redeploying current version v${VERSION}."
+          echo "NEW_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      # Push to main with no release-worthy commits → bail cleanly.
       - name: No release — exit
         if: env.NEW_VERSION == ''
         run: |


### PR DESCRIPTION
## Summary

Done. The workflow now falls back to the `package.json` version when a manual `workflow_dispatch` rerun produces no new release — so triggering with an empty `tag` will redeploy the current version (e.g. `v1.6.0`) instead of skipping. Push-to-main with no release-worthy commits still bails cleanly.

## Commits

- `f606b72` feat: Rerun releases with same version
- `3c0f7b1` chore(release): 1.6.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Allow re-running the release pipeline with the same version

## Context

When the user manually triggers the **Release & Deploy** workflow (`workflow_dispatch`) without providing a `tag` input, the workflow runs `semantic-release`. If there are no `feat:` / `fix:` / `BREAKING CHANGE:` commits since the last tag, semantic-release decides no new version is warranted and exits without setting `NEW_VERSION`. The workflow then hits the **"No release — exit"** step (`.github/workflows/release.yml:86-90`) and bails before building/deploying.

The user's intent in that case is "redeploy the current version" — not "create a new tag." Today they have to dig out the latest tag (e.g. `v1.6.0`) and re-run the workflow with that value pasted into the `tag` input. We should make this the natural default: when a manual run produces no new release, fall back to deploying the version already in `package.json`.

## Recommended approach

Replace the **No release — exit** step with a fallback that, on `workflow_dispatch` only, reads `package.json` and sets `NEW_VERSION` from it. On `push` events the existing skip behaviour is preserved (we don't want every chore commit to redeploy automatically).

### Files to modify

- `.github/workflows/release.yml` — single step change between lines 86 and 91.

### Change

Replace this block:

```yaml
# No release? Bail cleanly. semantic-release skips on chore/docs-only diffs.
- name: No release — exit
  if: env.NEW_VERSION == ''
  run: |
    echo "semantic-release decided no version bump is warranted. Skipping deploy."
    exit 0
```

with:

```yaml
# Manual dispatch with empty tag and no new version warranted → redeploy
# the version currently in package.json (i.e. the latest released version).
- name: Fallback to package.json version (manual rerun)
  if: env.NEW_VERSION == '' && github.event_name == 'workflow_dispatch'
  run: |
    VERSION="$(node -p "require('./package.json').version")"
    echo "No new release from semantic-release. Redeploying current version v${VERSION}."
    echo "NEW_VERSION=${VERSION}" >> "$GITHUB_ENV"

# Push to main with no release-worthy commits → bail cleanly (unchanged behaviour).
- name: No release — exit
  if: env.NEW_VERSION == ''
  run: |
    echo "semantic-release decided no version bump is warranted. Skipping deploy."
    exit 0
```

### Why this shape

- **Path A unchanged for pushes:** A `chore:` or `docs:` commit on `main` still skips deploy — we don't want every doc change to push a redundant image.
- **Path B unchanged:** Manual dispatch with an explicit `tag` still redeploys that exact tag.
- **New: manual dispatch with empty tag, no new release** → uses `package.json` version. `package.json` is updated by the `@semantic-release/git` plugin on every release (see `.releaserc.json:17`), so it always reflects the latest released version.
- The downstream Docker build + GHCR push will overwrite the existing `:1.6.0` and `:latest` tags with a fresh image built from current `main`. That is the intended "rerun" behaviour: same version label, current code.

### Caveat to flag in the workflow comment

Re-running with the same version means the GHCR image tag `1.6.0` gets overwritten — anyone pulling `1.6.0` after the rerun will get the new image. For this self-hosted single-VPS setup that's fine (the user *is* the only consumer), and it's also already true today when the user uses the existing `tag` input path.

## Verification

After editing the workflow:

1. **Static check** — open the file in GitHub's Actions UI or run `npx action-validator .github/workflows/release.yml` locally to confirm YAML is valid.
2. **Dry run on a branch** — push the edit on a throwaway branch, then trigger **Run workflow** from the Actions tab against `main` with `tag` left blank. With no new feat/fix commits, expect:
   - `Semantic release` step logs "no release published"
   - `Fallback to package.json version (manual rerun)` step prints `Redeploying current version v1.6.0` and sets `NEW_VERSION`
   - `No release — exit` step is skipped
   - Build, push, and SSH deploy steps all run
3. **VPS sanity check** — after deploy, `docker compose ps` on the VPS should show the `oche-app-1` container restarted within the workflow window, and `/api/health` (or the landing page) responds 200.
4. **Regression check on push path** — a subsequent `chore: ...` commit on main should still hit "No release — exit" and not redeploy.

</details>

## Original Request

**Rerun releases with same version**

> I woukd like to be able to rerun the release pipeline that should the same version again.currently it seams the release will be skipped

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)