### PR TITLE
Implement functional Rematch game creation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,7 +38,7 @@ Ideas and planned features for OCHE, roughly grouped by area. Not prioritised to
 
 ## Match flow improvements
 
-- [ ] **Rematch flow** — after summary, "Rematch" auto-creates a new game with same config and sends both players back.
+- [x] **Rematch flow** — after summary, "Rematch" auto-creates a new game with same config and sends both players back.
 - [x] **Checkout suggestions** — smart finish hints shown in the scoring UI (up to 170, 1/2/3-dart combos from `lib/checkouts.ts`).
 - [ ] **Undo across turns** — currently undo works within a turn; allow undoing the previous completed turn.
 - [ ] **Per-game detail view** — click into a finished game to see full leg-by-leg breakdown, dart-by-dart replay data.

--- a/app/(app)/match/[id]/MatchClient.tsx
+++ b/app/(app)/match/[id]/MatchClient.tsx
@@ -31,6 +31,7 @@ export function MatchClient({ game: initialGame, currentUserId, tournamentId }: 
   const [copied, setCopied] = useState(false);
   const [copiedFor, setCopiedFor] = useState<number | null>(null);
   const [friends, setFriends] = useState<FriendEntry[]>([]);
+  const [rematchPending, setRematchPending] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const gameId = initialGame.id;
@@ -98,6 +99,22 @@ export function MatchClient({ game: initialGame, currentUserId, tournamentId }: 
   };
 
   const goLobby = () => router.push("/lobby");
+
+  const handleRematch = async () => {
+    if (rematchPending) return;
+    setRematchPending(true);
+    const res = await fetch("/api/games", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rematchOf: gameId }),
+    });
+    if (!res.ok) {
+      setRematchPending(false);
+      return;
+    }
+    const newGame: Game = await res.json();
+    router.replace(`/match/${newGame.id}`);
+  };
 
   // ── Visitor: invited player sees a join screen ────────────────────────────
   if (status === "waiting" && !isCreator) {
@@ -218,12 +235,14 @@ export function MatchClient({ game: initialGame, currentUserId, tournamentId }: 
 
   // ── Match finished ────────────────────────────────────────────────────────
   if (status === "finished" && match?.winner != null) {
+    const isTraining = match.config.mode === "training";
     return (
       <SummaryScreen
         match={match}
-        onRestart={goLobby}
+        onRestart={isTraining ? goLobby : handleRematch}
         onNewMatch={goLobby}
         onBackToTournament={tournamentId ? () => router.push(`/tournament/${tournamentId}`) : undefined}
+        rematching={rematchPending}
       />
     );
   }

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
-import { createGame, getMyGames } from "@/lib/db/games";
+import { createGame, getMyGames, rematchGame } from "@/lib/db/games";
 import type { GameConfig } from "@/lib/types";
 
 export async function GET() {
@@ -15,7 +15,23 @@ export async function POST(req: Request) {
   const user = await getCurrentUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { guestName, ...config }: GameConfig & { guestName?: string } = await req.json();
+  const body = (await req.json()) as (GameConfig & { guestName?: string }) | { rematchOf: string };
+
+  if ("rematchOf" in body && body.rematchOf) {
+    try {
+      const game = await rematchGame(user.id, user.email, body.rematchOf);
+      return NextResponse.json(game, { status: 201 });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Rematch failed";
+      const status = msg.includes("not found") ? 404
+        : msg.includes("Not a participant") ? 403
+        : msg.includes("Training") ? 400
+        : 500;
+      return NextResponse.json({ error: msg }, { status });
+    }
+  }
+
+  const { guestName, ...config } = body as GameConfig & { guestName?: string };
   const game = await createGame(user.id, user.email, config as GameConfig, guestName);
   return NextResponse.json(game, { status: 201 });
 }

--- a/components/summary/SummaryScreen.tsx
+++ b/components/summary/SummaryScreen.tsx
@@ -13,9 +13,10 @@ interface Props {
   onRestart: () => void;
   onNewMatch: () => void;
   onBackToTournament?: () => void;
+  rematching?: boolean;
 }
 
-export function SummaryScreen({ match, onRestart, onNewMatch, onBackToTournament }: Props) {
+export function SummaryScreen({ match, onRestart, onNewMatch, onBackToTournament, rematching }: Props) {
   if (match.config.mode === "training" && match.training) {
     return (
       <TrainingSummary match={match} onNewMatch={onNewMatch} onRestart={onRestart} />
@@ -102,9 +103,10 @@ export function SummaryScreen({ match, onRestart, onNewMatch, onBackToTournament
             <>
               <button
                 onClick={onRestart}
-                className="f-display font-black text-2xl uppercase px-6 py-4 flex items-center gap-3 bg-electric text-ink"
+                disabled={rematching}
+                className="f-display font-black text-2xl uppercase px-6 py-4 flex items-center gap-3 bg-electric text-ink disabled:opacity-60"
               >
-                Rematch <RotateCcw className="w-6 h-6" strokeWidth={3} />
+                {rematching ? "Creating…" : "Rematch"} <RotateCcw className="w-6 h-6" strokeWidth={3} />
               </button>
               <button
                 onClick={onNewMatch}

--- a/lib/db/games.ts
+++ b/lib/db/games.ts
@@ -67,6 +67,37 @@ export async function createGame(
   return rowToGame(row);
 }
 
+export async function rematchGame(
+  userId: number,
+  userEmail: string,
+  originalGameId: string,
+): Promise<Game> {
+  const db = requireSql();
+  const [row] = await db`
+    SELECT g.config, g.player1_id, g.player2_id, g.match_state
+    FROM games g
+    WHERE g.id = ${originalGameId}
+  `;
+  if (!row) throw new Error("Original game not found");
+
+  const player1Id = Number(row.player1_id);
+  const player2Id = row.player2_id ? Number(row.player2_id) : null;
+  if (player1Id !== userId && player2Id !== userId) {
+    throw new Error("Not a participant in original game");
+  }
+
+  const config = row.config as GameConfig;
+  if (config.mode === "training") throw new Error("Training games cannot be rematched");
+
+  if (player2Id === null) {
+    const matchState = row.match_state as Match | null;
+    const guestName = matchState?.config.players[1]?.trim() || "Guest";
+    return createGame(userId, userEmail, config, guestName);
+  }
+
+  return createGame(userId, userEmail, config);
+}
+
 export async function joinGame(gameId: string, player2: { id: number; email: string }): Promise<Game> {
   const db = requireSql();
 


### PR DESCRIPTION
## Summary

All gates pass: `tsc --noEmit` clean, 60/60 tests pass, `next build` succeeds.

Changes made:
- `lib/db/games.ts:70` — added `rematchGame(userId, userEmail, originalGameId)` helper that loads the original config, validates participation, and routes to `createGame` with or without a `guestName` (extracted from `match_state.config.players[1]`).
- `app/api/games/route.ts` — POST now branches on a `rematchOf` field; maps thrown errors to 404/403/400.
- `app/(app)/match/[id]/MatchClient.tsx` — added `rematchPending` state and `handleRematch`; replaces `onRestart` for non-training games. Uses `router.replace` so the back button doesn't return to the finished match and `/lobby` is never traversed.
- `components/summary/SummaryScreen.tsx` — accepts `rematching?: boolean`, dims the Rematch button and shows "Creating…" while in flight.
- `BACKLOG.md:41` — ticked the Rematch flow as done.

Training games keep their existing `goLobby` behavior (TrainingSummary unchanged), and tournament context still wins via `onBackToTournament` (unchanged).

## Commits

- `7b2ea60` feat: Implement functional Rematch game creation
- `63a9724` chore(release): 1.7.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Make the Rematch button actually create a new game

## Context

The Rematch button on the post-match `SummaryScreen` is currently a no-op — `onRestart` is wired to `goLobby` in `app/(app)/match/[id]/MatchClient.tsx:224`, so clicking it just kicks the user back to `/lobby`. The BACKLOG entry at `BACKLOG.md:41` calls for the button to auto-create a new game with the same config and route both players to it.

We want a single button click to:
- For an invited (account-vs-account) game: create a new **waiting** game with the same config, navigate the clicker to `/match/<newId>` so they can share the new invite link, and let the opponent accept via the existing join flow.
- For a guest/local game: create a new **active** game with the same config and the same guest name, and navigate straight into the new match.
- Skip in tournament context (the existing `onBackToTournament` branch already takes precedence — no change needed there).
- Leave training alone — `TrainingSummary` shares the `onRestart` prop but its semantics ("Practice again") aren't a multiplayer rematch, so we keep its current goLobby behavior.

## Implementation

### 1. `lib/db/games.ts` — add `rematchGame` helper

Add a new exported function below `createGame`:

```ts
export async function rematchGame(
  userId: number,
  userEmail: string,
  originalGameId: string,
): Promise<Game> {
  const db = requireSql();
  const [row] = await db`
    SELECT g.config, g.player1_id, g.player2_id, g.match_state
    FROM games g
    WHERE g.id = ${originalGameId}
  `;
  if (!row) throw new Error("Original game not found");

  const player1Id = Number(row.player1_id);
  const player2Id = row.player2_id ? Number(row.player2_id) : null;
  if (player1Id !== userId && player2Id !== userId) {
    throw new Error("Not a participant in original game");
  }

  const config = row.config as GameConfig;
  if (config.mode === "training") throw new Error("Training games cannot be rematched");

  // Guest game: reuse the guest name baked into the original match state and
  // create a new active local game.
  if (player2Id === null) {
    const matchState = row.match_state as Match | null;
    const guestName = matchState?.config.players[1]?.trim() || "Guest";
    return createGame(userId, userEmail, config, guestName);
  }

  // Invited game: create a new waiting game; opponent will accept via the
  // existing /match/[id] join flow.
  return createGame(userId, userEmail, config);
}
```

Reuses the existing `createGame` for both code paths — no change to `createGame` itself, since it already produces an active local game when given a `guestName` and a waiting invite game otherwise.

### 2. `app/api/games/route.ts` — accept `rematchOf` in POST

Update the POST handler to branch on a new optional `rematchOf` field:

```ts
import { createGame, getMyGames, rematchGame } from "@/lib/db/games";

export async function POST(req: Request) {
  const user = await getCurrentUser();
  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

  const body = (await req.json()) as (GameConfig & { guestName?: string }) | { rematchOf: string };

  if ("rematchOf" in body && body.rematchOf) {
    try {
      const game = await rematchGame(user.id, user.email, body.rematchOf);
      return NextResponse.json(game, { status: 201 });
    } catch (err) {
      const msg = err instanceof Error ? err.message : "Rematch failed";
      const status = msg.includes("not found") ? 404
        : msg.includes("Not a participant") ? 403
        : msg.includes("Training") ? 400
        : 500;
      return NextResponse.json({ error: msg }, { status });
    }
  }

  const { guestName, ...config } = body as GameConfig & { guestName?: string };
  const game = await createGame(user.id, user.email, config as GameConfig, guestName);
  return NextResponse.json(game, { status: 201 });
}
```

### 3. `app/(app)/match/[id]/MatchClient.tsx` — wire up the rematch handler

In the finished-match branch (lines 220-228), replace `onRestart={goLobby}` with a real handler. Add at top-level inside `MatchClient`:

```ts
const [rematchPending, setRematchPending] = useState(false);

const handleRematch = async () => {
  if (rematchPending) return;
  setRematchPending(true);
  const res = await fetch("/api/games", {
    method: "POST",
    headers: { "Content-Type": "application/json" },
    body: JSON.stringify({ rematchOf: gameId }),
  });
  if (!res.ok) {
    setRematchPending(false);
    return;
  }
  const newGame: Game = await res.json();
  // replace (not push) so the browser back button doesn't return to the
  // finished match — and we never bounce through /lobby.
  router.replace(`/match/${newGame.id}`);
};
```

Update the SummaryScreen render:

```tsx
if (status === "finished" && match?.winner != null) {
  const isTraining = match.config.mode === "training";
  return (
    <SummaryScreen
      match={match}
      onRestart={isTraining ? goLobby : handleRematch}
      onNewMatch={goLobby}
      onBackToTournament={tournamentId ? () => router.push(`/tournament/${tournamentId}`) : undefined}
      rematching={rematchPending}
    />
  );
}
```

### 4. `components/summary/SummaryScreen.tsx` — pending state for the button

Add an optional `rematching?: boolean` prop. While `rematching` is true, dim/disable the Rematch CTA to prevent double-submits and signal in-flight work:

```tsx
interface Props {
  match: Match;
  onRestart: () => void;
  onNewMatch: () => void;
  onBackToTournament?: () => void;
  rematching?: boolean;
}
```

In the non-tournament branch (lines 102-117), update the Rematch button:

```tsx
<button
  onClick={onRestart}
  disabled={rematching}
  className="f-display font-black text-2xl uppercase px-6 py-4 flex items-center gap-3 bg-electric text-ink disabled:opacity-60"
>
  {rematching ? "Creating…" : "Rematch"} <RotateCcw className="w-6 h-6" strokeWidth={3} />
</button>
```

Don't forward `rematching` to `TrainingSummary` — training's `onRestart` is unchanged (still `goLobby`), and TrainingSummary does not receive the prop.

No CTA-skip logic needed: tournament context already wins via the `onBackToTournament` branch, and guest rematch is supported.

### 5. `BACKLOG.md` — tick the entry

`BACKLOG.md:41` — change `- [ ]` to `- [x]`.

## Critical files

- `lib/db/games.ts` — add `rematchGame`
- `app/api/games/route.ts` — branch on `rematchOf` in POST
- `app/(app)/match/[id]/MatchClient.tsx` — `handleRematch`, `rematchPending`, swap `onRestart`
- `components/summary/SummaryScreen.tsx` — add `rematching` prop, dim button
- `BACKLOG.md` — tick

## Reused existing utilities

- `createGame(userId, email, config, guestName?)` in `lib/db/games.ts:27` handles both invite (no guestName → `status='waiting'`) and local (`guestName` → `status='active'` with pre-built match_state). The rematch helper just orchestrates which arguments to pass.
- `match.config.players[1]` already holds the original guest name (`createGame` puts it there at game creation), so we don't need a separate `guest_name` column.
- The existing `/match/[id]` waiting-creator screen (`MatchClient.tsx:143-217`) already provides "Waiting for opponent" + copy-link UX for the new invite, so no new UI is needed for the invite-rematch beat.
- `getCurrentUser()` provides `user.email`, so we don't need a redundant DB lookup in the route handler.

## Verification

1. **Unit/type/build gates:**
   - `npm test` — all 24 Vitest tests pass (no scoring-engine touch).
   - `npx tsc --noEmit` — zero errors.
   - `npm run build` — Next.js build succeeds with standalone output.

2. **Manual UAT in the browser** (`docker compose up -d --build app` + open `http://localhost:3000`):
   - **Invited game:** create an invite game with config "best of 1, double-out, 301", have a second account join, finish the leg. From either client click Rematch → URL becomes `/match/<newId>` directly (no `/lobby` flash) → clicker sees "Waiting for opponent" with the copy-link UI; the other account can navigate to the new URL and see the join screen.
   - **Guest game:** create a local game with guest "Tom", finish the leg, click Rematch → URL becomes `/match/<newId>` and the active match starts with player names "<you>" vs "Tom" preserved. No waiting screen.
   - **Tournament match:** finish a tournament leg → SummaryScreen shows "Back to tournament" CTA only; no Rematch button rendered. (Existing branch — confirms we didn't regress it.)
   - **Training:** finish a drill → "Practice again" still routes to `/lobby` (no API call, no error).
   - **Double-click guard:** click Rematch twice quickly → only one new game row created; button shows "Creating…" while in flight.

3. **DB check** (optional):
   `docker compose exec db psql -U oche -d oche -c "SELECT id, status, player2_id FROM games ORDER BY created_at DESC LIMIT 5;"` → confirm new rows: invite rematch is `waiting`/`player2_id=NULL`, guest rematch is `active`/`player2_id=NULL`.

4. **BACKLOG check:** `grep "Rematch flow" BACKLOG.md` → shows `- [x]`.

</details>

## Original Request

**Implement functional Rematch game creation**

> The Rematch button on the post-match SummaryScreen is currently a no-op — it just routes back to /lobby. Make it actually create a new game with the same config and same opponent.
> 
> Files likely to touch:
> - app/(app)/match/[id]/MatchClient.tsx (lines ~220-228): replace `onRestart={goLobby}` with a real handler that calls a new endpoint and routes to the new match URL.
> - app/api/games/route.ts (POST): accept an optional `rematchOf` field carrying the prior game ID, copy that game's config, and either create a waiting game (if both players had accounts) or an active local/training game (if it was a guest game).
> - lib/db/games.ts createGame(): support a rematch flow — reuse the original config, and if both player IDs exist, create the new game with status='waiting' and player2_id NULL so the opponent must accept the new invite via the existing /match/[id] join flow.
> - components/summary/SummaryScreen.tsx: keep the Rematch CTA only when a rematch is actually possible (skip in tournament context — onBackToTournament already takes precedence; skip for guest games unless we choose to support a guest rematch).
> 
> UX details:
> - For invite-style rematches: creator clicks Rematch → POST creates new waiting game → router.push(/match/<newId>) → opponent sees the new invite. Show a brief 'rematch invite sent — share link' beat if needed.
> - For guest/local games: clicking Rematch should create a new active game with the same opponent name and immediately route both clients (only one device anyway) to the new match.
> - For training: not applicable — TrainingSummary already has its own buttons.
> 
> Success criteria:
> - Clicking Rematch produces a new game row with the same GameConfig and a new id, the URL changes to /match/<newId>, and the original /lobby is not visited as an intermediate stop.
> - All 24 vitest tests still pass; `next build` succeeds; `tsc --noEmit` clean.
> - Update BACKLOG.md to tick the Rematch flow as done.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)