### PR TITLE
Build public player profile pages

### DIFF
--- a/app/(app)/player/[id]/page.tsx
+++ b/app/(app)/player/[id]/page.tsx
@@ -1,0 +1,35 @@
+import { redirect, notFound } from "next/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { getUserById } from "@/lib/db/users";
+import { getGameHistory } from "@/lib/db/history";
+import { getHeadToHead } from "@/lib/db/friends";
+import { PlayerProfilePage } from "@/components/profile/PlayerProfilePage";
+
+export const dynamic = "force-dynamic";
+
+export default async function PlayerProfileServerPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const viewer = await getCurrentUser();
+  if (!viewer) redirect("/login");
+
+  const { id } = await params;
+  const targetId = Number(id);
+  if (!Number.isInteger(targetId) || targetId <= 0) notFound();
+
+  const target = await getUserById(targetId);
+  if (!target) notFound();
+
+  const isSelf = viewer.id === target.id;
+
+  const [games, h2h] = await Promise.all([
+    getGameHistory(target.id),
+    isSelf ? Promise.resolve(null) : getHeadToHead(viewer.id, target.id),
+  ]);
+
+  return (
+    <PlayerProfilePage target={target} viewer={viewer} games={games} h2h={h2h} />
+  );
+}

--- a/components/history/GameRow.tsx
+++ b/components/history/GameRow.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+import type { GameHistoryItem } from "@/lib/db/history";
+
+export function timeAgo(date: Date | string): string {
+  const secs = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(date).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
+interface Props {
+  game: GameHistoryItem;
+  /** Where the row navigates to on click. Pass `null` to render non-interactive (e.g. when the viewer wasn't a participant). */
+  href: string | null;
+}
+
+export function GameRow({ game: g, href }: Props) {
+  const router = useRouter();
+  const interactive = href !== null;
+
+  const handleNavigate = () => {
+    if (href) router.push(href);
+  };
+
+  const opponentLink = g.opponentUserId !== null && g.opponentUserId !== undefined ? (
+    <Link
+      href={`/player/${g.opponentUserId}`}
+      onClick={(e) => e.stopPropagation()}
+      className="f-display font-black text-base hover:text-electric transition-colors"
+      style={{ color: g.isGuestGame ? "#6d736f" : "#f2e8d0" }}
+    >
+      vs {g.opponent}
+    </Link>
+  ) : (
+    <span className="f-display font-black text-base" style={{ color: g.isGuestGame ? "#6d736f" : "#f2e8d0" }}>
+      vs {g.opponent}
+    </span>
+  );
+
+  return (
+    <div
+      role={interactive ? "button" : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      onClick={interactive ? handleNavigate : undefined}
+      onKeyDown={
+        interactive
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleNavigate();
+              }
+            }
+          : undefined
+      }
+      className={`border border-border-soft flex items-center justify-between px-4 py-3 gap-3 ${
+        interactive ? "cursor-pointer hover:border-border transition-colors" : ""
+      }`}
+      style={{
+        background: g.isGuestGame ? "#0c0f0e" : g.result === "win" ? "#0f1a12" : "#0e1010",
+        opacity: g.isGuestGame ? 0.5 : 1,
+      }}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className="f-display font-black text-base"
+            style={{ color: g.isGuestGame ? "#6d736f" : g.result === "win" ? "#d4ff3a" : "#e63946" }}
+          >
+            {g.result === "win" ? "W" : "L"}
+          </span>
+          {opponentLink}
+          <span className="f-mono text-xs text-muted">
+            {g.legsWon}–{g.legsLost}
+          </span>
+          {g.isGuestGame && (
+            <span className="f-mono text-[9px] uppercase text-muted border border-border-soft px-1.5 py-0.5" style={{ letterSpacing: "0.15em" }}>
+              guest · unranked
+            </span>
+          )}
+        </div>
+        <div className="f-mono text-[11px] text-muted mt-0.5 flex items-center gap-3 flex-wrap">
+          <span>
+            avg <span className="text-bone">{g.threeDartAvg.toFixed(2)}</span>
+          </span>
+          {g.tonEighty > 0 && (
+            <span className="text-oche-red font-bold">{g.tonEighty} × 180</span>
+          )}
+          {g.bestFinish > 0 && (
+            <span>
+              best out <span className="text-bone">{g.bestFinish}</span>
+            </span>
+          )}
+          <span className="ml-auto">{timeAgo(g.date)}</span>
+        </div>
+      </div>
+      <div className="shrink-0 text-right flex items-center gap-2">
+        <div className="f-mono text-[10px] text-muted" style={{ letterSpacing: "0.1em" }}>
+          {g.config.mode === "highlow" ? "HIGH-LOW" : `${g.config.startingScore}`}
+        </div>
+        {interactive && <ChevronRight className="w-3.5 h-3.5 text-muted" />}
+      </div>
+    </div>
+  );
+}

--- a/components/history/HistoryPage.tsx
+++ b/components/history/HistoryPage.tsx
@@ -1,29 +1,19 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ArrowLeft, ChevronRight, Trophy, Target } from "lucide-react";
+import { ArrowLeft, Trophy, Target } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
+import { GameRow, timeAgo } from "@/components/history/GameRow";
 import type { GameHistoryItem, TournamentHistoryItem } from "@/lib/db/history";
 import type { TournamentFormat, User } from "@/lib/types";
 import { displayName as dn } from "@/lib/display";
 import { drillLabel } from "@/lib/format";
+import { aggregateRankedStats } from "@/lib/stats";
 
 interface Props {
   games: GameHistoryItem[];
   tournaments: TournamentHistoryItem[];
   user: User;
-}
-
-function timeAgo(date: Date | string): string {
-  const secs = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
-  if (secs < 60) return "just now";
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(date).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
 }
 
 function formatLabel(format: TournamentFormat): string {
@@ -49,16 +39,9 @@ export function HistoryPage({ games, tournaments, user }: Props) {
   const router = useRouter();
 
   // Aggregate stats — guest + training games are excluded from stats (but still shown in the list)
-  const rankedGames = games.filter((g) => !g.isGuestGame && !g.isTraining);
   const trainingGames = games.filter((g) => g.isTraining);
   const matchGames = games.filter((g) => !g.isTraining);
-  const totalGames = rankedGames.length;
-  const wins = rankedGames.filter((g) => g.result === "win").length;
-  const winRate = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0;
-  const avgSum = rankedGames.reduce((s, g) => s + g.threeDartAvg, 0);
-  const avg = totalGames > 0 ? (avgSum / totalGames).toFixed(2) : "—";
-  const total180s = rankedGames.reduce((s, g) => s + g.tonEighty, 0);
-  const bestFinish = rankedGames.reduce((best, g) => (g.bestFinish > best ? g.bestFinish : best), 0);
+  const { totalGames, winRate, threeDartAvg: avg, total180s, bestFinish } = aggregateRankedStats(games);
 
   return (
     <div className="min-h-screen flex flex-col bg-ink">
@@ -111,70 +94,7 @@ export function HistoryPage({ games, tournaments, user }: Props) {
             ) : (
               <div className="space-y-1.5">
                 {matchGames.map((g) => (
-                  <div
-                    key={g.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => router.push(`/history/${g.id}`)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        router.push(`/history/${g.id}`);
-                      }
-                    }}
-                    className="border border-border-soft flex items-center justify-between px-4 py-3 gap-3 cursor-pointer hover:border-border transition-colors"
-                    style={{
-                      background: g.isGuestGame ? "#0c0f0e" : g.result === "win" ? "#0f1a12" : "#0e1010",
-                      opacity: g.isGuestGame ? 0.5 : 1,
-                    }}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span
-                          className="f-display font-black text-base"
-                          style={{ color: g.isGuestGame ? "#6d736f" : g.result === "win" ? "#d4ff3a" : "#e63946" }}
-                        >
-                          {g.result === "win" ? "W" : "L"}
-                        </span>
-                        <span className="f-display font-black text-base" style={{ color: g.isGuestGame ? "#6d736f" : "#f2e8d0" }}>
-                          vs {g.opponent}
-                        </span>
-                        <span className="f-mono text-xs text-muted">
-                          {g.legsWon}–{g.legsLost}
-                        </span>
-                        {g.isGuestGame && (
-                          <span className="f-mono text-[9px] uppercase text-muted border border-border-soft px-1.5 py-0.5" style={{ letterSpacing: "0.15em" }}>
-                            guest · unranked
-                          </span>
-                        )}
-                      </div>
-                      <div className="f-mono text-[11px] text-muted mt-0.5 flex items-center gap-3 flex-wrap">
-                        <span>
-                          avg{" "}
-                          <span className="text-bone">{g.threeDartAvg.toFixed(2)}</span>
-                        </span>
-                        {g.tonEighty > 0 && (
-                          <span className="text-oche-red font-bold">
-                            {g.tonEighty} × 180
-                          </span>
-                        )}
-                        {g.bestFinish > 0 && (
-                          <span>
-                            best out <span className="text-bone">{g.bestFinish}</span>
-                          </span>
-                        )}
-                        <span className="ml-auto">{timeAgo(g.date)}</span>
-                      </div>
-                    </div>
-                    <div className="shrink-0 text-right flex items-center gap-2">
-                      <div className="f-mono text-[10px] text-muted" style={{ letterSpacing: "0.1em" }}>
-                        {g.config.mode === "highlow"
-                          ? "HIGH-LOW"
-                          : `${g.config.startingScore}`}
-                      </div>
-                      <ChevronRight className="w-3.5 h-3.5 text-muted" />
-                    </div>
-                  </div>
+                  <GameRow key={g.id} game={g} href={`/history/${g.id}`} />
                 ))}
               </div>
             )}
@@ -299,7 +219,7 @@ function Section({ label, count, children }: { label: string; count: number; chi
   );
 }
 
-function StatBox({ label, value, highlight, accent }: { label: string; value: string; highlight?: boolean; accent?: boolean }) {
+export function StatBox({ label, value, highlight, accent }: { label: string; value: string; highlight?: boolean; accent?: boolean }) {
   return (
     <div className="border border-border-soft p-4" style={{ background: "#0d1210" }}>
       <div className="f-mono text-[9px] uppercase text-muted mb-1" style={{ letterSpacing: "0.2em" }}>{label}</div>

--- a/components/profile/PlayerProfilePage.tsx
+++ b/components/profile/PlayerProfilePage.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { BrandMark } from "@/components/ui/primitives";
+import { Avatar } from "@/components/ui/Avatar";
+import { GameRow, timeAgo } from "@/components/history/GameRow";
+import { StatBox } from "@/components/history/HistoryPage";
+import { displayName as dn } from "@/lib/display";
+import { aggregateRankedStats, rankedFilter, recentForm } from "@/lib/stats";
+import type { GameHistoryItem } from "@/lib/db/history";
+import type { HeadToHead, User } from "@/lib/types";
+
+interface Props {
+  target: User;
+  viewer: User;
+  games: GameHistoryItem[];
+  h2h: HeadToHead | null;
+}
+
+function joinedSince(date: Date | string): string {
+  return new Date(date).toLocaleDateString("en-GB", { month: "short", year: "numeric" });
+}
+
+export function PlayerProfilePage({ target, viewer, games, h2h }: Props) {
+  const router = useRouter();
+  const isSelf = viewer.id === target.id;
+  const targetName = dn(target.email, target.displayName);
+
+  const stats = aggregateRankedStats(games);
+  const form = recentForm(games, 10);
+  const rankedRecent = rankedFilter(games).slice(0, 10);
+
+  // Set of game ids the viewer participated in (for clickable rows on someone else's profile)
+  const viewerParticipantIds = new Set<string>(h2h?.recent.map((m) => m.gameId) ?? []);
+  const canLink = (gameId: string) => isSelf || viewerParticipantIds.has(gameId);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-ink">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft">
+        <BrandMark />
+        <button
+          onClick={() => router.back()}
+          className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
+          style={{ letterSpacing: "0.18em" }}
+        >
+          <ArrowLeft className="w-3.5 h-3.5" /> Back
+        </button>
+      </div>
+
+      <div className="flex-1 px-6 py-10 max-w-3xl w-full mx-auto">
+        <div className="rise">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="h-px w-10 bg-oche-red" />
+            <span className="f-mono text-xs uppercase text-oche-red" style={{ letterSpacing: "0.25em" }}>
+              player
+            </span>
+          </div>
+
+          {/* Hero */}
+          <div className="flex items-center gap-5 mb-8">
+            <Avatar name={targetName} color={target.avatarColor} size="lg" />
+            <div className="min-w-0">
+              <h1
+                className="f-display font-black leading-[0.9] text-cream uppercase truncate"
+                style={{ fontSize: "clamp(32px, 5.5vw, 56px)" }}
+              >
+                {targetName}
+              </h1>
+              <div className="f-mono text-xs text-muted mt-1">{target.email}</div>
+              <div className="f-mono text-[10px] uppercase text-muted mt-2" style={{ letterSpacing: "0.2em" }}>
+                since {joinedSince(target.createdAt)}
+                {isSelf && <span className="text-electric ml-2">· you</span>}
+              </div>
+            </div>
+          </div>
+
+          {/* StatBox row */}
+          {stats.totalGames > 0 ? (
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 mb-10">
+              <StatBox label="Games" value={String(stats.totalGames)} />
+              <StatBox label="Win rate" value={`${stats.winRate}%`} highlight={stats.winRate >= 50} />
+              <StatBox label="3-dart avg" value={stats.threeDartAvg} />
+              <StatBox label="180s" value={String(stats.total180s)} accent={stats.total180s > 0} />
+              <StatBox label="Best out" value={stats.bestFinish > 0 ? String(stats.bestFinish) : "—"} />
+            </div>
+          ) : (
+            <div className="border border-border-soft px-5 py-6 mb-10 f-mono text-sm text-muted text-center" style={{ background: "#0d1210" }}>
+              No ranked games yet.
+            </div>
+          )}
+
+          {/* Recent form */}
+          <Section label="Recent form">
+            {form.length === 0 ? (
+              <p className="f-mono text-xs text-muted">No ranked games yet.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {form.map((r, i) => (
+                  <span
+                    key={i}
+                    className="f-mono font-bold text-xs flex items-center justify-center"
+                    style={{
+                      width: 24,
+                      height: 24,
+                      background: r === "win" ? "#d4ff3a" : "#e63946",
+                      color: r === "win" ? "#0a0e0c" : "#f2e8d0",
+                    }}
+                    title={r === "win" ? "Win" : "Loss"}
+                  >
+                    {r === "win" ? "W" : "L"}
+                  </span>
+                ))}
+              </div>
+            )}
+          </Section>
+
+          {/* Head-to-head — only when viewing someone else and there's at least one meeting */}
+          {!isSelf && h2h && h2h.gamesPlayed > 0 && (
+            <Section label="Head-to-head vs you">
+              <div className="grid grid-cols-3 gap-2 mb-3">
+                <StatBox label="Games" value={String(h2h.gamesPlayed)} />
+                <StatBox
+                  label="Your win %"
+                  value={`${Math.round((h2h.viewerWins / h2h.gamesPlayed) * 100)}%`}
+                  highlight={h2h.viewerWins / h2h.gamesPlayed >= 0.5}
+                />
+                <StatBox
+                  label="Last meeting"
+                  value={h2h.lastMeeting ? timeAgo(h2h.lastMeeting) : "—"}
+                />
+              </div>
+              <div className="space-y-1.5">
+                {h2h.recent.map((m) => (
+                  <Link
+                    key={m.gameId}
+                    href={`/history/${m.gameId}`}
+                    className="border border-border-soft flex items-center justify-between px-4 py-2.5 gap-3 hover:border-border transition-colors"
+                    style={{ background: m.viewerWon ? "#0f1a12" : "#0e1010" }}
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span
+                        className="f-mono font-bold text-xs flex items-center justify-center shrink-0"
+                        style={{
+                          width: 22,
+                          height: 22,
+                          background: m.viewerWon ? "#d4ff3a" : "#e63946",
+                          color: m.viewerWon ? "#0a0e0c" : "#f2e8d0",
+                        }}
+                      >
+                        {m.viewerWon ? "W" : "L"}
+                      </span>
+                      <span className="f-display font-black text-base text-cream">
+                        {m.viewerLegs} — {m.targetLegs}
+                      </span>
+                    </div>
+                    <span className="f-mono text-[11px] text-muted">{timeAgo(m.finishedAt)}</span>
+                  </Link>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {/* Recent matches */}
+          <Section label="Recent matches" count={rankedRecent.length}>
+            {rankedRecent.length === 0 ? (
+              <p className="f-mono text-xs text-muted">No ranked games yet.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {rankedRecent.map((g) => (
+                  <GameRow
+                    key={g.id}
+                    game={g}
+                    href={canLink(g.id) ? `/history/${g.id}` : null}
+                  />
+                ))}
+              </div>
+            )}
+          </Section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({ label, count, children }: { label: string; count?: number; children: React.ReactNode }) {
+  return (
+    <div className="mb-10">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="h-px w-6 bg-border" />
+        <span className="f-mono text-xs uppercase text-muted" style={{ letterSpacing: "0.25em" }}>
+          {label}
+        </span>
+        {count !== undefined && count > 0 && (
+          <span className="f-mono text-xs text-muted">({count})</span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/components/settings/SettingsPage.tsx
+++ b/components/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { ArrowLeft, UserPlus, Check, X, Trash2 } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
@@ -320,7 +321,12 @@ export function SettingsPage({ user, friends: initialFriends, requests: initialR
                     <div className="flex items-center gap-3 min-w-0">
                       <Avatar name={dn(f.email, f.displayName)} color={f.avatarColor} />
                       <div>
-                        <div className="f-display font-black text-cream text-base">{dn(f.email, f.displayName)}</div>
+                        <Link
+                          href={`/player/${f.userId}`}
+                          className="f-display font-black text-cream text-base hover:text-electric transition-colors"
+                        >
+                          {dn(f.email, f.displayName)}
+                        </Link>
                         <div className="f-mono text-[11px] text-muted flex gap-3">
                           <span>{f.email}</span>
                           {f.gamesPlayed !== undefined && f.gamesPlayed > 0 && (
@@ -376,10 +382,13 @@ export function SettingsPage({ user, friends: initialFriends, requests: initialR
                         <td className="px-3 py-3">
                           <div className="flex items-center gap-2">
                             <Avatar name={dn(entry.email, entry.displayName)} color={entry.avatarColor} size="sm" />
-                            <span className="f-display font-black text-cream text-base">
+                            <Link
+                              href={`/player/${entry.userId}`}
+                              className="f-display font-black text-cream text-base hover:text-electric transition-colors"
+                            >
                               {dn(entry.email, entry.displayName)}
                               {entry.isSelf && <span className="text-electric text-xs ml-1.5">you</span>}
-                            </span>
+                            </Link>
                           </div>
                         </td>
                         <td className="px-3 py-3 f-mono text-sm text-bone">{entry.gamesPlayed ?? "—"}</td>

--- a/lib/db/friends.ts
+++ b/lib/db/friends.ts
@@ -1,5 +1,5 @@
 import { sql } from "@/lib/db";
-import type { FriendEntry } from "@/lib/types";
+import type { FriendEntry, HeadToHead, HeadToHeadRecentMatch, Match } from "@/lib/types";
 
 function requireSql() {
   if (!sql) throw new Error("DATABASE_URL is not configured");
@@ -68,29 +68,83 @@ export async function getFriends(userId: number): Promise<FriendEntry[]> {
 
   const friends = rows.map((r) => rowToFriend(r, userId));
 
-  // Attach aggregate stats for each friend
-  for (const f of friends) {
-    const [stats] = await db`
-      SELECT
-        COUNT(*) FILTER (WHERE g.status = 'finished') AS games_played,
-        COUNT(*) FILTER (
-          WHERE g.status = 'finished'
-            AND g.match_state IS NOT NULL
-            AND (g.match_state->>'winner')::int =
-              CASE WHEN g.player1_id = ${f.userId} THEN 0 ELSE 1 END
-        ) AS wins
-      FROM games g
-      WHERE g.status = 'finished'
-        AND g.player2_id IS NOT NULL
-        AND (g.player1_id = ${f.userId} OR g.player2_id = ${f.userId})
-    `;
-    const gamesPlayed = Number(stats.games_played ?? 0);
-    const wins = Number(stats.wins ?? 0);
-    f.gamesPlayed = gamesPlayed;
-    f.winRate = gamesPlayed > 0 ? Math.round((wins / gamesPlayed) * 100) : 0;
-  }
+  // Attach true head-to-head stats for each friend (viewer vs that friend only).
+  await Promise.all(
+    friends.map(async (f) => {
+      const h2h = await getHeadToHead(userId, f.userId);
+      f.gamesPlayed = h2h.gamesPlayed;
+      f.winRate =
+        h2h.gamesPlayed > 0
+          ? Math.round((h2h.viewerWins / h2h.gamesPlayed) * 100)
+          : 0;
+    }),
+  );
 
   return friends;
+}
+
+export async function getHeadToHead(
+  viewerId: number,
+  targetId: number,
+): Promise<HeadToHead> {
+  if (viewerId === targetId) {
+    return { gamesPlayed: 0, viewerWins: 0, targetWins: 0, lastMeeting: null, recent: [] };
+  }
+  const db = sql;
+  if (!db) {
+    return { gamesPlayed: 0, viewerWins: 0, targetWins: 0, lastMeeting: null, recent: [] };
+  }
+
+  const rows = await db`
+    SELECT g.id, g.finished_at, g.player1_id, g.player2_id, g.match_state
+    FROM games g
+    WHERE g.status = 'finished'
+      AND g.match_state IS NOT NULL
+      AND (
+        (g.player1_id = ${viewerId} AND g.player2_id = ${targetId})
+        OR (g.player1_id = ${targetId} AND g.player2_id = ${viewerId})
+      )
+    ORDER BY g.finished_at DESC NULLS LAST
+  `;
+
+  let viewerWins = 0;
+  let targetWins = 0;
+  const recent: HeadToHeadRecentMatch[] = [];
+  let lastMeeting: Date | null = null;
+
+  for (const row of rows) {
+    try {
+      const match = row.match_state as Match;
+      if (match.winner === null) continue;
+      const viewerIsP1 = Number(row.player1_id) === viewerId;
+      const viewerIdx = (viewerIsP1 ? 0 : 1) as 0 | 1;
+      const targetIdx = (1 - viewerIdx) as 0 | 1;
+      const viewerWon = match.winner === viewerIdx;
+      if (viewerWon) viewerWins += 1;
+      else targetWins += 1;
+      const finishedAt = (row.finished_at as Date) ?? new Date();
+      if (lastMeeting === null) lastMeeting = finishedAt;
+      if (recent.length < 5) {
+        recent.push({
+          gameId: row.id as string,
+          finishedAt,
+          viewerLegs: match.legsWon[viewerIdx],
+          targetLegs: match.legsWon[targetIdx],
+          viewerWon,
+        });
+      }
+    } catch {
+      // skip malformed records
+    }
+  }
+
+  return {
+    gamesPlayed: viewerWins + targetWins,
+    viewerWins,
+    targetWins,
+    lastMeeting,
+    recent,
+  };
 }
 
 export async function sendFriendRequest(

--- a/lib/db/history.ts
+++ b/lib/db/history.ts
@@ -15,6 +15,8 @@ export interface GameHistoryItem {
   id: string;
   date: Date;
   opponent: string;
+  /** User id of the opponent, or null for guest / training games */
+  opponentUserId: number | null;
   config: GameConfig;
   result: "win" | "loss";
   legsWon: number;
@@ -85,6 +87,7 @@ export async function getGameHistory(
           id: row.id as string,
           date: (row.finished_at as Date) ?? new Date(),
           opponent: "",
+          opponentUserId: null,
           config: row.config as GameConfig,
           result: "win",
           legsWon: 0,
@@ -115,11 +118,17 @@ export async function getGameHistory(
       const opponent = opponentEmail
         ? displayName(opponentEmail, opponentDisplayName)
         : match.config.players[opponentIdx];
+      const opponentRawId = isPlayer1 ? row.player2_id : row.player1_id;
+      const opponentUserId =
+        opponentRawId === null || opponentRawId === undefined
+          ? null
+          : Number(opponentRawId);
 
       items.push({
         id: row.id as string,
         date: (row.finished_at as Date) ?? new Date(),
         opponent,
+        opponentUserId,
         config: row.config as GameConfig,
         result: match.winner === playerIdx ? "win" : "loss",
         legsWon: match.legsWon[playerIdx],

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,48 @@
+// lib/stats.ts — pure aggregation helpers for GameHistoryItem lists.
+// No DB / I/O — same purity contract as lib/scoring.ts and lib/tournament.ts.
+
+import type { GameHistoryItem } from "@/lib/db/history";
+
+export interface AggregateRankedStats {
+  totalGames: number;
+  wins: number;
+  losses: number;
+  /** 0–100, rounded */
+  winRate: number;
+  /** "29.45" or "—" */
+  threeDartAvg: string;
+  total180s: number;
+  /** 0 if no checkout recorded */
+  bestFinish: number;
+}
+
+/** Guest games and training sessions don't count toward ranked stats. */
+export function rankedFilter(games: GameHistoryItem[]): GameHistoryItem[] {
+  return games.filter((g) => !g.isGuestGame && !g.isTraining);
+}
+
+export function aggregateRankedStats(games: GameHistoryItem[]): AggregateRankedStats {
+  const ranked = rankedFilter(games);
+  const totalGames = ranked.length;
+  const wins = ranked.filter((g) => g.result === "win").length;
+  const losses = totalGames - wins;
+  const winRate = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0;
+  const avgSum = ranked.reduce((s, g) => s + g.threeDartAvg, 0);
+  const threeDartAvg = totalGames > 0 ? (avgSum / totalGames).toFixed(2) : "—";
+  const total180s = ranked.reduce((s, g) => s + g.tonEighty, 0);
+  const bestFinish = ranked.reduce(
+    (best, g) => (g.bestFinish > best ? g.bestFinish : best),
+    0,
+  );
+  return { totalGames, wins, losses, winRate, threeDartAvg, total180s, bestFinish };
+}
+
+/** Last `n` ranked results, newest first (matches the order returned by getGameHistory). */
+export function recentForm(
+  games: GameHistoryItem[],
+  n = 10,
+): ("win" | "loss")[] {
+  return rankedFilter(games)
+    .slice(0, n)
+    .map((g) => g.result);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,10 +18,26 @@ export interface FriendEntry {
   avatarColor: string;
   status: "pending" | "accepted";
   direction: "incoming" | "outgoing";
-  // aggregate stats — only populated for accepted friends
+  // head-to-head stats vs the viewer — only populated for accepted friends
   gamesPlayed?: number;
-  winRate?: number;      // 0–100
+  winRate?: number;      // 0–100, viewer's win rate against this friend
   threeDartAvg?: number;
+}
+
+export interface HeadToHeadRecentMatch {
+  gameId: string;
+  finishedAt: Date;
+  viewerLegs: number;
+  targetLegs: number;
+  viewerWon: boolean;
+}
+
+export interface HeadToHead {
+  gamesPlayed: number;
+  viewerWins: number;
+  targetWins: number;
+  lastMeeting: Date | null;
+  recent: HeadToHeadRecentMatch[]; // newest first, max 5
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary

Done. Summary of what landed:

**New files**
- `app/(app)/player/[id]/page.tsx` — server route, `force-dynamic`, parses + validates id, fetches user + game history + H2H in parallel, `notFound()` on bad/unknown ids
- `components/profile/PlayerProfilePage.tsx` — hero (avatar + name + email + "since {Mon YYYY}"), 5-cell StatBox row (games / win rate / avg / 180s / best out), Recent form W/L pill strip, H2H card (only if not self & meetings exist), Recent matches list using `<GameRow>`
- `components/history/GameRow.tsx` — extracted row component with `href: string | null` so non-participant games render non-interactive (no chevron, no cursor) on someone else's profile
- `lib/stats.ts` — pure helpers `aggregateRankedStats`, `rankedFilter`, `recentForm`

**Updates**
- `lib/types.ts` — added `HeadToHead` + `HeadToHeadRecentMatch`; updated `FriendEntry` comment to reflect viewer-vs-friend semantics
- `lib/db/history.ts` — added `opponentUserId: number | null` on `GameHistoryItem`, populated from `player1_id`/`player2_id`
- `lib/db/friends.ts` — new `getHeadToHead(viewerId, targetId)` helper; `getFriends()` now uses it so per-friend `gamesPlayed`/`winRate` are true viewer-vs-that-friend stats (the previous SQL aggregated all the friend's games)
- `components/history/HistoryPage.tsx` — uses `aggregateRankedStats`, renders games via `<GameRow>`, exports `StatBox` for reuse
- `components/settings/SettingsPage.tsx` — friend list names + leaderboard names now `<Link href="/player/{userId}">`

**Verification**
- `npx tsc --noEmit` — zero errors
- `npm test` — 60/60 pass
- `npm run build` — clean; `/player/[id]` registered (2.05 kB)

## Commits

- `415e0bd` feat: Build public player profile pages
- `63a9724` chore(release): 1.7.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Plan — Public Player Profile Pages (`/player/[id]`)

## Context

The roadmap (CLAUDE.md → Phase 6) lists "global leaderboard + player profile pages" as the remaining work. The data needed for a profile is already exposed elsewhere — opponent display names appear in match history, tournaments, the friends list, and the friend leaderboard — so making profiles visible to any signed-in user adds no new privacy surface; it just turns names that already render into clickable, deeper destinations.

This PR delivers the profile page itself, plus the two link surfaces needed to reach it: history opponent names and friends-list / leaderboard names. `/history/[id]` already exists and guards participant-only access via `notFound()`, so the recent-matches list on the profile must avoid linking to games the viewer wasn't in (otherwise a click 404s).

While in here we also fix a long-standing bug in `getFriends()`: the per-friend "win rate" shown on the friends list and leaderboard is actually the user's **overall** win rate (its SQL forgets to constrain the opponent), not their true head-to-head record. We swap it to use the new H2H helper so the friends list and leaderboard tell the truth.

---

## Files

### New

**`app/(app)/player/[id]/page.tsx`** — server page
- `export const dynamic = "force-dynamic"` (CLAUDE.md gotcha #1).
- Match the Next 15 async-params pattern from `app/(app)/match/[id]/page.tsx:8` and `app/(app)/tournament/[id]/page.tsx:8`: `params: Promise<{ id: string }>`, `await params`.
- Parse `id` to a number; if `Number.isNaN`, call `notFound()`.
- Fetch in parallel:
  - `getCurrentUser()` (the layout already enforces auth, but we need the viewer id for H2H + participant checks).
  - `getUserById(targetId)` — `notFound()` if null.
  - `getGameHistory(targetId)` — already user-parameterised in `lib/db/history.ts`; returns games from the **target's** POV (their `result`, their `opponent`, etc.).
  - `getHeadToHead(viewer.id, targetId)` — new helper (see below). Skip if `viewer.id === targetId`.
- Render `<PlayerProfilePage target={target} viewer={user} games={games} h2h={h2h} />`.

**`components/profile/PlayerProfilePage.tsx`** — presentational, server-rendered (no client state needed; mirrors `HistoryPage` which is a `"use client"` component but we can stay server-only since there's no interactivity beyond `<Link>`).
- Props: `target: User`, `viewer: User`, `games: GameHistoryItem[]`, `h2h: HeadToHead | null`.
- Voice/tokens copied from `HistoryPage.tsx` (same brand palette, no new tokens).
- Sections:
  1. **Hero** — `<Avatar size="lg" name={dn(target.email, target.displayName)} color={target.avatarColor} />` next to: display name in `f-display font-black uppercase text-3xl text-cream`, email in `text-muted text-xs f-mono`, and a "since {Month YYYY}" tag (Tag primitive in `components/ui/primitives.tsx`).
  2. **StatBox row** — identical markup to `HistoryPage.tsx:99-104`: `grid grid-cols-2 sm:grid-cols-4 gap-2 mb-10` with Games / Win rate / 3-dart avg / 180s. Use the StatBox copied from HistoryPage (or extract — see below). Uses `aggregateRankedStats(games)`.
     - Add a fifth `Best finish` cell underneath as a separate single-cell box (or stretch the grid to `sm:grid-cols-5`) so we don't lose the metric the spec calls out. Decision: extend the grid to 5 cells on `sm:` and keep 2 cols on mobile — visually consistent with HistoryPage which already shows best finish per-row.
  3. **Recent form** — last 10 ranked results as 24×24 W/L pills. W = `bg-electric text-ink`, L = `bg-oche-red text-cream`, both `f-mono font-bold text-xs flex items-center justify-center`. Empty state = "no ranked games yet" in `text-muted`.
  4. **Head-to-head card** (only if `viewer.id !== target.id` and `h2h && h2h.gamesPlayed > 0`):
     - Title `vs you` in `f-mono uppercase text-xs text-electric`.
     - Three StatBoxes: games, viewer-POV win rate (highlight green if ≥ 50%), last meeting (relative — reuse the same `timeAgo` helper used by HistoryPage; check if it's exported).
     - Below: a 5-row recent-meetings list with W/L pill + leg score (e.g. `3 — 2`) + relative date. Each row links to `/history/{gameId}` (viewer is by definition a participant in any H2H game).
  5. **Recent matches** — 10 most recent ranked games (skip guest+training, same filter as `aggregateRankedStats`).
     - Reuse the row markup from `HistoryPage.tsx:113-178`.
     - Each row navigates to `/history/{g.id}` **only if** the viewer participated. Participation check: `target.id === viewer.id || (h2hGameIds.has(g.id))` — i.e. either the viewer is the target user, or the game appears in the viewer-vs-target H2H set we already fetched. (For "viewing someone else, game vs. a third party," the viewer wasn't in it → row is rendered but not clickable / no chevron.)
     - To keep the row component shared, factor the row out of HistoryPage into `components/history/GameRow.tsx` taking `{ game, href? }` — when `href` is null it renders as a plain non-interactive `<div>` without `cursor-pointer` / chevron.

### Updates

**`lib/types.ts`**
- Extend `GameHistoryItem` with `opponentUserId: number | null` (null when guest).
- Add new exported type:
  ```
  HeadToHead = {
    gamesPlayed: number;
    viewerWins: number;
    targetWins: number;
    lastMeeting: Date | null;
    recent: HeadToHeadRecentMatch[];   // newest first, max 5
  }
  HeadToHeadRecentMatch = {
    gameId: string;
    finishedAt: Date;
    viewerLegs: number;
    targetLegs: number;
    viewerWon: boolean;
  }
  ```
- Existing `FriendEntry.winRate` semantics change to **true H2H** (no type change needed).

**`lib/db/history.ts`**
- Add `player1_id, player2_id` to the SELECT in `getGameHistory` (lines 47–60). They're already JOINed-to via u1/u2; just expose them.
- Populate `opponentUserId` on each returned `GameHistoryItem`: the column not equal to the requested `userId`, or `null` for guest games.
- No other behaviour change. The function is already user-parameterised, so it works unchanged for any target user.

**`lib/stats.ts`** (new pure helper file — chosen over inlining per Q2)
- Mirrors the I/O-free style of `lib/scoring.ts` and `lib/tournament.ts`.
- Exports:
  ```
  aggregateRankedStats(games: GameHistoryItem[]): {
    totalGames: number;
    wins: number;
    losses: number;
    winRate: number;        // 0–100, rounded
    threeDartAvg: string;   // "29.45" or "—"
    total180s: number;
    bestFinish: number;     // 0 if none
  }
  rankedFilter(games: GameHistoryItem[]): GameHistoryItem[]
  recentForm(games: GameHistoryItem[], n = 10): ("win"|"loss")[]
  ```
- Lifts the inline logic at `components/history/HistoryPage.tsx:51-61` verbatim. HistoryPage now imports from `lib/stats.ts` instead of computing inline.

**`lib/db/friends.ts`**
- Add `getHeadToHead(viewerId, targetId)` returning `HeadToHead`:
  ```sql
  SELECT id, finished_at, player1_id, player2_id, match_state
    FROM games
   WHERE status = 'finished'
     AND ((player1_id = $viewerId AND player2_id = $targetId)
       OR (player1_id = $targetId AND player2_id = $viewerId))
   ORDER BY finished_at DESC
  ```
  - For each row, hydrate `match_state` (it's the `Match` JSONB) → derive `viewerLegs`, `targetLegs`, `viewerWon` from `match.legsWon` indexed by which player slot the viewer is in. (Same approach as `lib/db/history.ts:106` does for stats.)
  - Aggregate counts; first row's `finished_at` is `lastMeeting`; first 5 rows go into `recent`.
- **Fix `getFriends()`**: replace its broken win-rate SQL (current query at lines 73–86 doesn't constrain to the friend) with a call to (or duplication of) the H2H query, so each friend's `gamesPlayed` and `winRate` reflect viewer-vs-that-friend only. Easiest path: in the existing `Promise.all` enrichment loop, call `getHeadToHead(userId, friend.userId)` per friend and read `gamesPlayed` + `viewerWins` off it.
- Note: `threeDartAvg` enrichment on `FriendEntry` (if present in the SQL) likely has the same scope bug — review and either fix or drop the field from the per-friend enrichment for consistency. Confirm during implementation by reading the current query end-to-end.

**`components/history/HistoryPage.tsx`**
- Drop the inline aggregate block (lines 51–61); call `aggregateRankedStats(rankedGames)` from `lib/stats.ts`.
- Extract the game-row JSX (lines 113–178) into `components/history/GameRow.tsx` taking `{ game: GameHistoryItem; href: string | null }`. HistoryPage maps each game to `<GameRow game={g} href={`/history/${g.id}`} />`.
- Inside `GameRow`, when `g.opponentUserId` is non-null, wrap the `vs {g.opponent}` span (currently line 140) in `<Link href={`/player/${g.opponentUserId}`} onClick={(e) => e.stopPropagation()}>` so it navigates to the profile without firing the row's outer click. Use `text-electric hover:underline` on hover to signal clickability without changing the at-rest look. Guest opponents (no userId) render as plain text.
- StatBox helper (lines 302–314) — leave in place; PlayerProfilePage imports it. (If it's not exported, mark it `export function StatBox`.)

**`components/settings/SettingsPage.tsx`**
- Friends list (lines 316–348): wrap the friend's display-name `<div>` (line 323) in `<Link href={`/player/${f.userId}`} className="hover:text-electric transition-colors">`. Don't make the whole row clickable — there are existing action buttons inside.
- Leaderboard (lines 355–396): wrap the name span at line 379 in the same `<Link href={`/player/${entry.userId}`}>`. Skip linking the "you" row to your own profile? — link it; it's harmless and matches "any signed-in user can visit."
- No change to friend-request rows in the same file (different action surface).

---

## Critical files to read while implementing

- `lib/db/history.ts:47-130` — query + opponent derivation
- `components/history/HistoryPage.tsx:51-178` — stats logic + row JSX to factor out
- `lib/db/friends.ts:72-91` — broken H2H to replace
- `lib/scoring.ts` `Match` shape (`legsWon`, `players`) — for hydrating H2H rows
- `app/(app)/match/[id]/page.tsx` and `app/(app)/tournament/[id]/page.tsx` — server-page conventions to copy
- `components/ui/Avatar.tsx`, `components/ui/primitives.tsx` (Tag) — reused on hero
- `lib/display.ts` — `displayName` helper for hero title

---

## Verification

End-to-end checks the user runs locally:
- `/player/<my-own-id>` → my hero, my StatBox row, my recent form, **no H2H card**, my recent matches all clickable.
- `/player/<friend-id>` → friend's hero + stats, H2H card vs viewer with games/win-rate/last meeting, recent matches: ones the viewer was in are clickable (chevron), ones vs. third parties render but aren't clickable.
- `/player/<unknown-numeric-id>` → Next's `notFound()` page.
- `/player/<non-numeric>` → `notFound()` page (parse-fail branch).
- `/history` → opponent names are now electric-on-hover links to `/player/<id>`; clicking the rest of the row still goes to `/history/<id>` (event propagation stopped on the inner link).
- `/settings` → friend names + leaderboard names are clickable to their profiles. Friend list win-rate column now reflects **head-to-head with you**, not overall.
- Tournament pages unchanged.

Test commands (per CLAUDE.md "Things to verify"):
```
npm test           # 24/24 still pass — no engine changes
npx tsc --noEmit   # zero errors (new types added to lib/types.ts)
npm run build      # full build incl. the new route
```

No DB migration. No env-var changes.

</details>

## Original Request

**Build public player profile pages**

> Build a public-within-the-app player profile page at `/player/[id]` that any signed-in user can visit (no friend requirement — visibility of names is already exposed by match history and tournaments).
> 
> New files:
> - app/(app)/player/[id]/page.tsx — server component (use `export const dynamic = "force-dynamic"` per CLAUDE.md gotcha #1). Fetch the target user via getUserById; 404 if missing. Compute that user's stats by reusing logic from lib/db/history.ts (extract a shared `aggregateRankedStats(games)` helper if needed). Also fetch head-to-head with the current viewer.
> - components/profile/PlayerProfilePage.tsx — render in the same brand voice as HistoryPage and SettingsPage:
>   * Hero block: avatar (Avatar component), display name (uppercase f-display), email subdued, 'since {createdAt}' tag.
>   * StatBox row: total ranked games, win rate, 3-dart avg, 180s, best finish (mirror HistoryPage StatBox).
>   * 'Recent form' strip — last 10 ranked results as W/L pills (electric green / oche-red).
>   * Head-to-head card vs viewer (only if not viewing own profile): games played, win rate from viewer's POV, last meeting date, recent ↔ scoreline. Reuse logic from lib/db/friends.ts head-to-head computation.
>   * Recent matches list (10 most recent ranked games) — same row layout as HistoryPage Games section, each row links to /history/{gameId} only if the viewer was a participant in that game.
> 
> Updates to existing surfaces:
> - components/history/HistoryPage.tsx: wrap the opponent name in a Link to /player/{opponentUserId} (history items currently expose opponent name string only — extend GameHistoryItem with `opponentUserId: number | null`, populated from games.player1_id/player2_id).
> - components/settings/SettingsPage.tsx friend list rows: link friend names to /player/{userId}.
> 
> Success criteria:
> - Visiting /player/<my-own-id> shows my stats (mirroring /history's aggregate bar).
> - Visiting /player/<friend-id> shows their stats and a head-to-head card; clicking one of their visible recent games either opens /history/<id> (if I was in it) or is non-clickable.
> - Visiting /player/<unknown-id> renders Next's notFound().
> - /history opponent names become clickable; tournament results pages are unchanged in this PR.
> - All vitest + tsc + next build green.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)