### PR TITLE
Keep player scores visible between turns

### DIFF
--- a/components/match/MatchScreen.tsx
+++ b/components/match/MatchScreen.tsx
@@ -41,6 +41,10 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
   const turnDarts = isTraining
     ? (match.training?.currentDarts ?? [])
     : match.currentLeg.currentTurnDarts;
+  const lastTurnP0 = match.currentLeg.turns[0].at(-1);
+  const lastTurnP1 = match.currentLeg.turns[1].at(-1);
+  const dartsForP0 = p === 0 ? turnDarts : (lastTurnP0?.darts ?? []);
+  const dartsForP1 = p === 1 ? turnDarts : (lastTurnP1?.darts ?? []);
   const stats = useMemo(() => computeStats(match), [match]);
 
   const needsDoubleIn =
@@ -206,7 +210,7 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
             showRemaining={isX01}
             active={p === 0}
             legsWon={match.legsWon[0]}
-            turnDarts={p === 0 ? turnDarts : []}
+            turnDarts={dartsForP0}
             side="left"
             accent="#d4ff3a"
             avg={stats[0].threeDartAvg}
@@ -222,7 +226,7 @@ export function MatchScreen({ match, setMatch, onExit, onFinish }: Props) {
             showRemaining={isX01}
             active={p === 1}
             legsWon={match.legsWon[1]}
-            turnDarts={p === 1 ? turnDarts : []}
+            turnDarts={dartsForP1}
             side="right"
             accent="#e63946"
             avg={stats[1].threeDartAvg}


### PR DESCRIPTION
## Summary

Type check clean (zero output = zero errors), 66/66 tests pass. The change is in place at `components/match/MatchScreen.tsx:44-47` (derivation) and `:213, :229` (props).

End of turn: inactive player's panel now displays their last completed turn's darts instead of empty slots; resets automatically when they become active again. Ready for you to play-test in the browser per the verification plan.

## Commits

- `8038f82` Merge origin/main into feature branch
- `694ef4e` feat: Keep player scores visible between turns
- `1462e90` chore(release): 1.10.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Keep last-turn darts visible while opponent throws

## Context

Currently in a match, when player A finishes their turn (3 darts or bust) and player B starts throwing, player A's three dart slots immediately reset to empty. This loses the comparison — you can't glance at the board mid-opponent-turn and see what the previous thrower scored.

The user wants both players' dart slots to stay populated until each player's *own* next turn begins, so during player B's throw you still see player A's three-dart breakdown for comparison.

## Root cause

`components/match/MatchScreen.tsx:209,225` always passes `[]` to the inactive player's `PlayerPanel`:

```tsx
turnDarts={p === 0 ? turnDarts : []}
```

The data we need already exists: `match.currentLeg.turns[player]` accumulates every completed `Turn`, and each `Turn` has a `darts: Dart[]` field (committed by `applyDartX01` / `applyDartHighLow` *before* `currentTurnDarts` is reset, see `lib/scoring.ts:214-216, 266`).

So instead of passing `[]` for the inactive player, we pass the darts of their last completed turn (or `[]` if they have no turns yet — start-of-leg).

## Implementation

Single file change: `components/match/MatchScreen.tsx`.

### Change 1 — compute display darts per player

Replace the `turnDarts` block at `MatchScreen.tsx:41-43` with a helper that returns the right darts per player:

```tsx
const turnDarts = isTraining
  ? (match.training?.currentDarts ?? [])
  : match.currentLeg.currentTurnDarts;

const lastCompletedDarts = (player: 0 | 1): Dart[] => {
  if (isTraining) return [];
  const turns = match.currentLeg.turns[player];
  return turns.length > 0 ? turns[turns.length - 1].darts : [];
};

const displayDarts = (player: 0 | 1): Dart[] =>
  p === player ? turnDarts : lastCompletedDarts(player);
```

(Add `Dart` to the existing `import type` from `@/lib/types` at the top of the file.)

### Change 2 — pass per-player darts to panels

`MatchScreen.tsx:209` — replace `turnDarts={p === 0 ? turnDarts : []}` with `turnDarts={displayDarts(0)}`.

`MatchScreen.tsx:225` — replace `turnDarts={p === 1 ? turnDarts : []}` with `turnDarts={displayDarts(1)}`.

No changes to `PlayerPanel.tsx`. The active-player visual cues that already exist there (`PlayerPanel.tsx:33-38` green top bar, `:44-46` accent avatar background, `:65-70` "on oche" tag, `:29` brighter background) make it clear which set of darts is current vs previous — we don't need to add a "prev" label.

## Why this works for all modes

- **X01 / HighLow** — both use the same `Leg.turns` + `currentTurnDarts` structure. `applyDartX01` and `applyDartHighLow` both push the completed `Turn` into `turns[p]` *before* clearing `currentTurnDarts` (`lib/scoring.ts:214-216` and `:298-300`), so the data is available the moment we render.
- **Training** — single-player path, `lastCompletedDarts` returns `[]` for both indices and we fall through to `match.training?.currentDarts ?? []`. Behavior unchanged.
- **Bust turns** — busts are still committed to `turns[p]` with `kind: "bust"`. Showing the busted darts is desirable — that's exactly the comparison the user wants ("they threw T20 T20 1 → busted on the 1").
- **Start of leg / match** — `turns[player]` is empty, helper returns `[]`, both panels start blank as today.

## Critical files

- `components/match/MatchScreen.tsx` — the only file edited (lines 41-43, 209, 225, plus `Dart` type import).
- `components/match/PlayerPanel.tsx` — unchanged, but worth noting `dart-in` animation at `:148` will trigger when the inactive panel transitions from empty → 3 darts at turn-flip. This should look like the previous player's darts "pop in" right as their turn ends — a nice visual confirmation. If it ends up jarring, we can suppress with a `wasJustCompleted` flag, but expect it to be fine.
- `lib/scoring.ts` / `lib/types.ts` — read-only references; no engine changes.

## Verification

1. `npx tsc --noEmit` — zero errors (only TS change is adding `Dart` to imports).
2. `npm test` — engine untouched, all 24 should still pass.
3. `npm run dev` and play a local game:
   - Player 1 throws 3 darts → confirm player 1's slots stay populated while player 2 throws their first dart, second dart, third dart.
   - Player 2 finishes their 3 darts → player 1's slots reset to empty (start of their new turn), player 2's slots stay populated showing what they just threw.
   - Trigger a bust on player 1 (e.g. go below 0 with double-out) → confirm the busted darts remain visible during player 2's turn.
   - Win a leg → confirm new leg starts with both panels empty (turns array reset by `makeFreshLeg`).
   - Switch a game to High-Low mode → confirm same behavior.
4. Visually verify the `dart-in` animation on turn-flip looks acceptable; if not, suppress for previous-turn renders.

</details>

## Original Request

**Keep player scores visible between turns**

> Currently when the other player Is on turn to throw the dots the points of the first player just vanish I think it would be better to have them Displayed for longer so that you have some comparison between the players and it's the next turn like after both players threw that out It can be reset but what time being it's better to have it for both of the players to see what the other one has festival

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)