### PR TITLE
Improve metric link invite email deliverability

### DIFF
--- a/app/api/auth/request/route.ts
+++ b/app/api/auth/request/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { findOrCreateUser } from "@/lib/db/users";
-import { createMagicToken } from "@/lib/db/tokens";
+import { countRecentMagicTokens, createMagicToken } from "@/lib/db/tokens";
 import { sendMagicLink } from "@/lib/email";
+
+const RATE_LIMIT_WINDOW_MINUTES = 5;
+const RATE_LIMIT_MAX = 3;
 
 export async function POST(req: Request) {
   try {
@@ -13,6 +16,16 @@ export async function POST(req: Request) {
 
     const normalised = email.trim().toLowerCase();
     const user = await findOrCreateUser(normalised);
+
+    // Cap magic-link emails to RATE_LIMIT_MAX per user per window. Silent reject
+    // (still 200) so we don't leak that the cap was hit and stay consistent with
+    // the existing "don't reveal whether the email exists" behaviour.
+    const recent = await countRecentMagicTokens(user.id, RATE_LIMIT_WINDOW_MINUTES);
+    if (recent >= RATE_LIMIT_MAX) {
+      console.warn(`[auth/request] rate-limited ${normalised} (${recent} recent tokens)`);
+      return NextResponse.json({ ok: true });
+    }
+
     const rawToken = await createMagicToken(user.id);
     const appUrl = process.env.APP_URL ?? "https://oche.cloud";
     const verifyUrl = `${appUrl}/api/auth/verify?token=${rawToken}`;

--- a/lib/db/tokens.ts
+++ b/lib/db/tokens.ts
@@ -14,6 +14,21 @@ function hashToken(raw: string) {
 const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+// Counts magic tokens issued for this user within the last `windowMinutes` minutes.
+// magic_tokens has no created_at column, but expires_at = creation + 15min, so
+// "issued in the last N minutes" ⇔ expires_at > now() + (15 - N) minutes.
+export async function countRecentMagicTokens(userId: number, windowMinutes: number): Promise<number> {
+  const db = requireSql();
+  const tokenLifetimeMinutes = TOKEN_TTL_MS / 60_000;
+  const cutoffMinutes = tokenLifetimeMinutes - windowMinutes;
+  const [row] = await db`
+    SELECT count(*)::int AS n FROM magic_tokens
+    WHERE user_id = ${userId}
+      AND expires_at > now() + (${cutoffMinutes} || ' minutes')::interval
+  `;
+  return Number(row?.n ?? 0);
+}
+
 // Returns the raw (unhashed) token to embed in the email link.
 export async function createMagicToken(userId: number): Promise<string> {
   const db = requireSql();

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,5 +1,7 @@
 // lib/email.ts — sends the magic login link via Resend
 
+import { randomUUID } from "node:crypto";
+
 export async function sendMagicLink(to: string, url: string): Promise<void> {
   // Always log the link — handy for local dev where email isn't wired up
   console.log(`[magic-link] ${to} → ${url}`);
@@ -11,6 +13,8 @@ export async function sendMagicLink(to: string, url: string): Promise<void> {
   // Sending domain must be verified in Resend — can differ from APP_URL's hostname
   const domain = process.env.RESEND_FROM_DOMAIN ?? new URL(appUrl).hostname;
 
+  const preheader = "Tap the button to finish signing in — link expires in 15 minutes.";
+
   const html = `
 <!DOCTYPE html>
 <html lang="en">
@@ -20,6 +24,7 @@ export async function sendMagicLink(to: string, url: string): Promise<void> {
   <title>Your OCHE login link</title>
 </head>
 <body style="margin:0;padding:0;background:#0a0e0c;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;">
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;line-height:1px;color:#0a0e0c;">${preheader}</div>
   <table width="100%" cellpadding="0" cellspacing="0" style="background:#0a0e0c;padding:48px 16px;">
     <tr>
       <td align="center">
@@ -56,6 +61,19 @@ export async function sendMagicLink(to: string, url: string): Promise<void> {
 </body>
 </html>`;
 
+  const text = `Sign in to OCHE
+==============
+
+Someone (hopefully you) requested a login link for ${to}.
+
+Open this link to sign in (expires in 15 minutes):
+${url}
+
+If you didn't request this, you can safely ignore this email. The link can only be used once.
+
+${domain}
+`;
+
   const res = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
@@ -67,6 +85,10 @@ export async function sendMagicLink(to: string, url: string): Promise<void> {
       to,
       subject: "Your OCHE login link",
       html,
+      text,
+      headers: {
+        "X-Entity-Ref-ID": randomUUID(),
+      },
     }),
   });
 


### PR DESCRIPTION
## Summary

Done. Summary of changes:

**`lib/email.ts`** — added a hidden preheader (better inbox preview), a plaintext alternative (the big one — HTML-only is the strongest spam signal), and an `X-Entity-Ref-ID` header per send. From/subject unchanged.

**`lib/db/tokens.ts`** — new `countRecentMagicTokens(userId, windowMinutes)` helper. Uses the `expires_at = creation + 15min` invariant to query "issued in the last N minutes" without a schema migration.

**`app/api/auth/request/route.ts`** — silent rate-limit at 3 magic-link requests per user per 5 minutes. Still returns `200 {ok: true}` on reject so the cap isn't observable to a caller.

`npx tsc --noEmit` is clean and `npm test` is 66/66.

Two things you can do to verify:
1. Send a real magic link to a Mail-Tester address (e.g. `test-abcd@srv1.mail-tester.com`) — should now hit 9.5+/10 with plaintext part flagged as present.
2. Optionally edit the Hostinger DMARC record to `v=DMARC1; p=none; rua=mailto:bjarne@arclytics.de` so you start getting visibility reports — pure DNS, no code involved.

Want me to commit these changes?

## Commits

- `c61944f` Merge origin/main into feature branch
- `31840de` feat: Improve metric link invite email deliverability
- `90d5540` chore(release): 1.11.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Improve magic-link email deliverability

## Context

The OCHE magic-link login email (sent via Resend from `noreply@contact.oche.cloud`) is
landing in Apple Mail's spam folder for `bjarne.meyn@icloud.com`. Looking at the actual
code in `lib/email.ts:14-71`, the email is sent with:

- HTML-only body (no `text` alternative) — strong spam signal on iCloud/Gmail
- No preheader text (the inbox preview just shows the first body line)
- No `headers` field on the Resend payload

DNS auth is already in place on Hostinger: Resend's `send.contact` MX is published, the
DKIM CNAMEs are presumably present (Resend wouldn't show the domain as verified
otherwise), and `_dmarc.oche.cloud` carries `v=DMARC1; p=none;` which covers
`contact.oche.cloud` via subdomain inheritance. So SPF/DKIM/DMARC are not the lever.

That means the spam classification is most likely about the message itself: HTML-only
bodies with a single CTA button + opaque token URL match the phishing template. The
fix is to make the message look unambiguously transactional: add a plaintext part, give
filters a unique reference header, and improve the inbox preview.

## Recommended changes

### Commit 1 — `lib/email.ts`: plaintext alternative + preheader + header

Modify the Resend payload at `lib/email.ts:65-70`:

- **Add `text`**: a plaintext fallback. Modern spam filters expect a `text/plain` MIME
  part alongside `text/html`; HTML-only is one of the strongest spam signals for
  transactional mail. Body: recipient's email, the URL on its own line, expiry note,
  abuse line. Around 6 lines.
- **Add `headers`**: `{ "X-Entity-Ref-ID": <crypto.randomUUID()> }`. Tells Gmail this
  is a unique transactional message (deduplicated correctly when multiple links arrive
  in quick succession). Lightweight, no downsides.
- **Do NOT add `Reply-To`** (per your earlier preference, keep `noreply@…` as-is).
- **Do NOT add `List-Unsubscribe`**: bulk-sender header; transactional auth mail is
  exempt and adding it can mis-categorize the message as bulk.

Add a hidden preheader to the HTML at `lib/email.ts:22` (just inside `<body>`, before
the table) so the inbox preview reads "Tap the button to finish signing in — link
expires in 15 minutes." instead of the raw first paragraph. Standard pattern:
`<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">…</div>`.

Keep `From: OCHE <noreply@${domain}>` and Subject `"Your OCHE login link"` unchanged.

### Commit 2 — `app/api/auth/request/route.ts`: rate-limit

Currently anyone can spam magic-link requests for any email, which torches domain
reputation if abused (and is a gift to anyone trying to harass a known user). Add a
simple Postgres-backed rate-limit before calling `sendMagicLink` at line 20:

- Cap to **3 requests per email per 5 minutes**.
- Reuse the existing `magic_tokens` table — no migration needed:

  ```ts
  const recent = await sql`select count(*)::int as n from magic_tokens
    where user_id = ${user.id} and created_at > now() - interval '5 minutes'`;
  if (recent[0].n >= 3) return NextResponse.json({ ok: true }); // silent reject
  ```
- Still return `200 {ok:true}` to avoid leaking that the cap was hit (and to stay
  consistent with the existing "don't reveal whether the email exists" pattern).
- IP rate-limit can be added later if abuse actually shows up; per-email is the
  important one here.

Will need a `created_at` column on `magic_tokens` — verify it exists in `001_auth.sql`
during execution; if not, add a tiny migration `006_magic_tokens_created_at.sql`.

### Skipped from earlier plan

- **README DNS checklist** — you already have SPF/DKIM/DMARC set up via Resend +
  Hostinger. Not adding documentation for something that's done.
- **BIMI / subdomain rename** — overkill for a hobby app.

## Optional DNS tweak (do it in Hostinger, not in code)

Your `_dmarc` TXT is `"v=DMARC1; p=none;"` — that's enough for alignment, but you get
zero visibility into who's sending mail as you. Consider editing it to:

```
v=DMARC1; p=none; rua=mailto:bjarne@arclytics.de
```

Aggregate XML reports will start arriving from Gmail/Microsoft/etc once a day. Useful
for confirming Resend traffic is actually authenticating, and for catching anyone
spoofing the domain. Skip if you don't want the inbox noise.

## Critical files

- `lib/email.ts` — modify lines 14-71: add hidden preheader in HTML, add `text` and
  `headers` fields to the Resend payload.
- `app/api/auth/request/route.ts` — add rate-limit check before `sendMagicLink` at
  line 20. Reuses `magic_tokens.created_at` (verify column exists).
- `lib/db/migrations/001_auth.sql` — read-only check for `created_at` on
  `magic_tokens`; only touch if missing.

## Verification

1. `npx tsc --noEmit` — zero errors.
2. `npm test` — engine tests still pass (24/24); no test changes for this work.
3. **Mail-Tester run**: trigger the login flow at `https://oche.cloud` with a
   Mail-Tester one-time address (e.g. `test-abcd@srv1.mail-tester.com`). Visit the
   result; aim for **9.5+/10**. Specifically check: SPF pass, DKIM pass, DMARC pass,
   plaintext part present, no spammy phrases.
4. **Real iCloud test**: send a link to `bjarne.meyn@icloud.com`. Confirm it arrives
   in the inbox, not Junk. (If it's still in Junk, mark it Not Junk once — that
   teaches the per-account filter and is sometimes needed for the first delivery
   after a body change.)
5. **Rate-limit test**: hit `POST /api/auth/request` 4× rapidly with the same email;
   the 4th should still return 200 but `select count(*) from magic_tokens where
   user_id = … and created_at > now() - interval '5 minutes'` should stay at 3.

</details>

## Original Request

**Improve metric link invite email deliverability**

> The current Mail for the metric link invite goes into the spam folder and I would like to avoid the somehow Maybe we can adjust the email that has been sent or are there any other ways we could proven This going into spam folders of the user because it's not really Professional and this happens

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)