### PR TITLE
Add visibility-aware polling hook

### DIFF
--- a/app/(app)/match/[id]/MatchClient.tsx
+++ b/app/(app)/match/[id]/MatchClient.tsx
@@ -9,6 +9,7 @@ import { SummaryScreen } from "@/components/summary/SummaryScreen";
 import { BrandMark } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
 import { displayName } from "@/lib/display";
+import { usePolling } from "@/lib/usePolling";
 
 interface Props {
   game: Game;
@@ -32,7 +33,6 @@ export function MatchClient({ game: initialGame, currentUserId, tournamentId }: 
   const [copiedFor, setCopiedFor] = useState<number | null>(null);
   const [friends, setFriends] = useState<FriendEntry[]>([]);
   const [rematchPending, setRematchPending] = useState(false);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const etagRef = useRef<string | null>(null);
 
   const gameId = initialGame.id;
@@ -50,16 +50,7 @@ export function MatchClient({ game: initialGame, currentUserId, tournamentId }: 
     if (g.matchState) setMatch(g.matchState);
   }, [gameId]);
 
-  useEffect(() => {
-    if (status === "finished") {
-      if (pollRef.current) clearInterval(pollRef.current);
-      return;
-    }
-    pollRef.current = setInterval(poll, 1500);
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
-  }, [status, poll]);
+  usePolling(poll, 1500, status !== "finished");
 
   const proxySetMatch = useCallback((newMatch: Match) => {
     setMatch(newMatch);

--- a/app/(app)/tournament/[id]/TournamentClient.tsx
+++ b/app/(app)/tournament/[id]/TournamentClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Copy, Check, Trophy, UserPlus } from "lucide-react";
 import type { FriendEntry, Tournament, User } from "@/lib/types";
@@ -10,6 +10,7 @@ import { BrandMark, Tag } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
 import { displayName as dn } from "@/lib/display";
 import { computeRankings } from "@/lib/tournament";
+import { usePolling } from "@/lib/usePolling";
 
 interface Props {
   tournament: Tournament;
@@ -34,7 +35,6 @@ export function TournamentClient({ tournament: initial, currentUserId, user }: P
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [friends, setFriends] = useState<FriendEntry[]>([]);
   const [inviting, setInviting] = useState<Record<number, boolean>>({});
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const userName = dn(user.email, user.displayName);
 
   const isPlayer = t.players.some((p) => p.userId === currentUserId);
@@ -46,16 +46,7 @@ export function TournamentClient({ tournament: initial, currentUserId, user }: P
     setT(await res.json());
   }, [t.id]);
 
-  useEffect(() => {
-    if (t.status === "finished") {
-      if (pollRef.current) clearInterval(pollRef.current);
-      return;
-    }
-    pollRef.current = setInterval(poll, 5000);
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
-  }, [t.status, poll]);
+  usePolling(poll, 5000, t.status !== "finished");
 
   useEffect(() => {
     if (!isCreator) return;

--- a/components/lobby/OpenGames.tsx
+++ b/components/lobby/OpenGames.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import type { Game, GameConfig } from "@/lib/types";
 import { drillLabel } from "@/lib/format";
+import { usePolling } from "@/lib/usePolling";
 
 function gameLabel(config: GameConfig): string {
   if (config.mode === "training") return drillLabel(config.drill ?? "doubles");
@@ -45,9 +46,8 @@ export function OpenGames({ currentUserId }: { currentUserId: number }) {
 
   useEffect(() => {
     fetchGames();
-    const interval = setInterval(fetchGames, 5000);
-    return () => clearInterval(interval);
   }, [fetchGames]);
+  usePolling(fetchGames, 5000);
 
   const leave = async (gameId: string) => {
     setLeaving(gameId);

--- a/components/settings/SettingsPage.tsx
+++ b/components/settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, UserPlus, Check, X, Trash2 } from "lucide-react";
@@ -8,6 +8,7 @@ import { BrandMark } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
 import type { User, FriendEntry } from "@/lib/types";
 import { displayName as dn } from "@/lib/display";
+import { usePolling } from "@/lib/usePolling";
 
 const PALETTE = [
   { hex: "#d4ff3a", label: "Electric" },
@@ -53,10 +54,7 @@ export function SettingsPage({ user, friends: initialFriends, requests: initialR
     }
   }, []);
 
-  useEffect(() => {
-    const interval = setInterval(refreshFriends, 10000);
-    return () => clearInterval(interval);
-  }, [refreshFriends]);
+  usePolling(refreshFriends, 10000);
 
   async function saveProfile() {
     setSaving(true);

--- a/components/tournament/YourTournaments.tsx
+++ b/components/tournament/YourTournaments.tsx
@@ -6,6 +6,7 @@ import { Trophy } from "lucide-react";
 import type { Tournament } from "@/lib/types";
 import { computeStandings } from "@/lib/tournament";
 import { displayName as dn } from "@/lib/display";
+import { usePolling } from "@/lib/usePolling";
 
 function timeAgo(date: Date | string): string {
   const secs = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
@@ -48,9 +49,8 @@ export function YourTournaments({ currentUserId }: { currentUserId: number }) {
 
   useEffect(() => {
     fetchTournaments();
-    const interval = setInterval(fetchTournaments, 5000);
-    return () => clearInterval(interval);
   }, [fetchTournaments]);
+  usePolling(fetchTournaments, 5000);
 
   if (tournaments.length === 0) return null;
 

--- a/lib/usePolling.ts
+++ b/lib/usePolling.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function usePolling(
+  fn: () => void | Promise<void>,
+  intervalMs: number,
+  enabled: boolean = true,
+) {
+  const fnRef = useRef(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof document === "undefined") return;
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(() => {
+        void fnRef.current();
+      }, intervalMs);
+    };
+
+    const stop = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        stop();
+      } else {
+        void fnRef.current();
+        start();
+      }
+    };
+
+    if (document.visibilityState !== "hidden") {
+      start();
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [intervalMs, enabled]);
+}


### PR DESCRIPTION
## Summary

Done. Summary of changes:

- **`lib/usePolling.ts`** (new) — wraps `setInterval`, pauses on `visibilitychange → hidden`, fires immediately on return to visible, gated by `enabled`. `fn` captured in a ref so callers can pass `useCallback`-wrapped functions without retearing the interval.
- **`MatchClient.tsx`** — dropped `pollRef` + polling effect; `usePolling(poll, 1500, status !== "finished")`.
- **`TournamentClient.tsx`** — dropped `pollRef` + `useRef` import + polling effect; `usePolling(poll, 5000, t.status !== "finished")`.
- **`OpenGames.tsx`** — kept on-mount fetch, replaced interval with `usePolling(fetchGames, 5000)`.
- **`YourTournaments.tsx`** — same pattern; kept on-mount fetch, added `usePolling(fetchTournaments, 5000)`.
- **`SettingsPage.tsx`** — dropped `useEffect` import and effect; `usePolling(refreshFriends, 10000)`.

Verification: `npx tsc --noEmit` → 0 errors; `npm test` → 66/66 passing. Manual smoke test (refresh lobby, switch tabs 30s, switch back) is the remaining check that needs to happen in a real browser.

## Commits

- `9ffbb72` Merge origin/main into feature branch
- `88be469` feat: Add visibility-aware polling hook
- `38bfe41` chore(release): 1.12.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Plan: Introduce `lib/usePolling.ts`

## Context

Five client components currently each spin up their own `setInterval` to poll the backend. None of them gate on tab visibility, so a backgrounded tab keeps fetching every 1.5s/5s/10s indefinitely — wasted requests, wasted battery, wasted DB cycles. We want a tiny shared hook that:

1. owns the interval lifecycle,
2. pauses while `document.visibilityState === 'hidden'`,
3. fires the function once immediately on `visible` and restarts the interval,
4. respects an `enabled` flag so callers like `MatchClient` can stop polling once the game is finished.

This is purely a client-side gate — no API changes, no interval-value changes, no schema work.

---

## The hook

**New file:** `lib/usePolling.ts`

```tsx
"use client";

import { useEffect, useRef } from "react";

export function usePolling(
  fn: () => void | Promise<void>,
  intervalMs: number,
  enabled: boolean = true,
) {
  const fnRef = useRef(fn);
  // keep latest fn in the ref so callers can pass useCallback'd functions
  // without resetting the interval each render
  useEffect(() => {
    fnRef.current = fn;
  });

  useEffect(() => {
    if (!enabled) return;
    if (typeof document === "undefined") return; // SSR guard

    let intervalId: ReturnType<typeof setInterval> | null = null;

    const start = () => {
      if (intervalId !== null) return;
      intervalId = setInterval(() => {
        void fnRef.current();
      }, intervalMs);
    };

    const stop = () => {
      if (intervalId !== null) {
        clearInterval(intervalId);
        intervalId = null;
      }
    };

    const onVisibilityChange = () => {
      if (document.visibilityState === "hidden") {
        stop();
      } else {
        void fnRef.current(); // fire immediately on return to foreground
        start();
      }
    };

    if (document.visibilityState !== "hidden") {
      start();
    }
    document.addEventListener("visibilitychange", onVisibilityChange);

    return () => {
      stop();
      document.removeEventListener("visibilitychange", onVisibilityChange);
    };
  }, [intervalMs, enabled]);
}
```

**Design notes (deliberate):**

- The hook does **not** fire `fn` on mount. The existing call sites that want a fresh fetch on mount (`OpenGames`, `YourTournaments`) already call their fetcher explicitly inside a `useEffect`; preserving that pattern keeps the diff minimal and behavior identical for those components.
- `fn` is captured in a ref and only the *interval* effect's deps are `[intervalMs, enabled]`. This means callers can pass `useCallback`-wrapped functions whose identity changes (e.g. when `t.id` changes) without tearing down/re-creating the interval needlessly.
- SSR guard (`typeof document === "undefined"`) is defensive only — these are all `"use client"` components, but it keeps the hook safe to import elsewhere.

---

## Call-site refactors

### 1. `app/(app)/match/[id]/MatchClient.tsx`

Currently lines 35, 53–62. Remove `pollRef` and the polling `useEffect`; keep `etagRef` (still used in `poll`).

```tsx
// add
import { usePolling } from "@/lib/usePolling";

// remove: const pollRef = useRef<...>(null);
// remove: the useEffect at lines 53–62

// add (after `poll` is defined):
usePolling(poll, 1500, status !== "finished");
```

`useRef` import stays (still needed for `etagRef`).

### 2. `app/(app)/tournament/[id]/TournamentClient.tsx`

Currently lines 37, 49–58. Remove `pollRef` and the polling `useEffect`.

```tsx
import { usePolling } from "@/lib/usePolling";

// remove: const pollRef = ...
// remove: useEffect at 49–58

usePolling(poll, 5000, t.status !== "finished");
```

`useRef` is no longer used here — drop it from the React import line (line 3).

### 3. `components/lobby/OpenGames.tsx`

Currently lines 46–50. Keep the on-mount fetch (existing behavior: list appears immediately, not after 5s).

```tsx
import { usePolling } from "@/lib/usePolling";

useEffect(() => {
  fetchGames();
}, [fetchGames]);
usePolling(fetchGames, 5000);
```

### 4. `components/tournament/YourTournaments.tsx`

Currently lines 49–53. Same shape as `OpenGames` — keep the on-mount fetch.

```tsx
import { usePolling } from "@/lib/usePolling";

useEffect(() => {
  fetchTournaments();
}, [fetchTournaments]);
usePolling(fetchTournaments, 5000);
```

### 5. `components/settings/SettingsPage.tsx`

Currently lines 56–59. No on-mount fetch today — just replace the effect.

```tsx
import { usePolling } from "@/lib/usePolling";

usePolling(refreshFriends, 10000);
```

---

## Files touched

- **new:** `lib/usePolling.ts`
- **edit:** `app/(app)/match/[id]/MatchClient.tsx`
- **edit:** `app/(app)/tournament/[id]/TournamentClient.tsx`
- **edit:** `components/lobby/OpenGames.tsx`
- **edit:** `components/tournament/YourTournaments.tsx`
- **edit:** `components/settings/SettingsPage.tsx`

No new dependencies. No tests added (hook is trivial and Vitest is configured for the pure scoring engine; adding a jsdom + RTL setup just for this is out of scope).

---

## Verification

1. `npx tsc --noEmit` — must report 0 errors.
2. `npm test` — all 24 scoring tests must still pass (we did not touch the engine; this just confirms nothing imported from these client files leaked into shared code paths).
3. `npm run build` — Next.js production build should succeed.
4. **Manual smoke test (the user-spec acceptance):**
   - `docker compose up -d` (or `npm run dev`).
   - Open `/lobby` while having a waiting game in your list.
   - Open DevTools → Network, filter on `/api/games`. Confirm a request every ~5s.
   - Switch to another tab; wait ~30s. Confirm **no** `/api/games` requests during that window.
   - Switch back. Confirm a fetch fires **immediately** on return, then the 5s cadence resumes.
   - Repeat for `/match/[id]` (1.5s cadence; should also stop polling once the match transitions to `finished`).
   - Repeat for `/tournament/[id]` (5s; stops on `finished`).
   - Open `/settings`; verify `/api/friends` polls every 10s and pauses while hidden.

</details>

## Original Request

**Add visibility-aware polling hook**

> Introduce a tiny `lib/usePolling.ts` hook that wraps `setInterval` and pauses while `document.visibilityState === 'hidden'`, resuming + immediately re-fetching on `visibilitychange` -> visible. Signature roughly: `usePolling(fn: () => void | Promise<void>, intervalMs: number, enabled?: boolean)`. Replace the raw `setInterval` calls in:
> 
> - `app/(app)/match/[id]/MatchClient.tsx`
> - `app/(app)/tournament/[id]/TournamentClient.tsx`
> - `components/lobby/OpenGames.tsx`
> - `components/tournament/YourTournaments.tsx`
> - `components/settings/SettingsPage.tsx`
> 
> Keep their existing `enabled` semantics (e.g. MatchClient stops when `status === 'finished'`). Verify no regressions: refresh the lobby with a waiting game, switch tabs for 30s, switch back — fetch should fire immediately on return. Don't change the API or polling intervals; this is purely a client-side gate. Type-check (`npx tsc --noEmit`) and run `npm test`.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)