### PR TITLE
Add per-player indexes to the games table

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -36,7 +36,7 @@ What's verified working:
 - **Friends system:** send/accept/decline/remove requests by email. Friend list with head-to-head stats + win rate leaderboard. Notification badge on lobby avatar when requests pending.
 - **Settings page** (`/settings`): edit display name, pick avatar colour, manage friends.
 - **Feedback button:** floating on all app pages, emails bjarne.meyn@icloud.com via Resend (or logs locally).
-- Applied migrations: `001_auth.sql` → `005_profiles.sql`
+- Applied migrations: `001_auth.sql` → `006_game_player_indexes.sql`
 
 ## Tech stack & why
 
@@ -205,7 +205,8 @@ oche/
 │           ├── 002_games.sql         games table
 │           ├── 003_tournaments.sql   tournaments, tournament_players, tournament_matches tables
 │           ├── 004_season_halves.sql ALTER tournaments ADD COLUMN season_halves
-│           └── 005_profiles.sql      ALTER users ADD display_name, avatar_color; CREATE friend_requests
+│           ├── 005_profiles.sql      ALTER users ADD display_name, avatar_color; CREATE friend_requests
+│           └── 006_game_player_indexes.sql  per-player composite indexes for getMyGames/getGameHistory
 ├── tests/
 │   └── scoring.test.ts               24 tests covering all rule branches
 ├── scripts/

--- a/lib/db/migrations/006_game_player_indexes.sql
+++ b/lib/db/migrations/006_game_player_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS games_player1_status_finished_idx ON games(player1_id, status, finished_at DESC);
+CREATE INDEX IF NOT EXISTS games_player2_status_finished_idx ON games(player2_id, status, finished_at DESC) WHERE player2_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Done. Summary:

- **`lib/db/migrations/006_game_player_indexes.sql`** — created with the two `CREATE INDEX IF NOT EXISTS` statements; the `player2_id` index is partial (`WHERE player2_id IS NOT NULL`).
- **`CLAUDE.md`** — added `006_game_player_indexes.sql` to the migrations tree (line 209) and bumped "Applied migrations" range to `001_auth.sql` → `006_game_player_indexes.sql`.
- **Applied cleanly**: first run printed `→ applying: 006_game_player_indexes.sql` / `✓ applied`. Second run printed `✓ already applied: 006_game_player_indexes.sql`.
- **`\d games`** confirms both indexes exist alongside the original `games_status_created_at_idx`.
- **EXPLAIN** (with `enable_seqscan=off` since the local table only has 10 rows) shows both target queries using `BitmapOr` over `Bitmap Index Scan on games_player1_status_finished_idx` + `games_player2_status_finished_idx`:
  - `getGameHistory`: index conditions `(player1_id = $1 AND status = 'finished')` and `(player2_id = $1 AND status = 'finished')` — full prefix match.
  - `getMyGames`: index conditions on player id only (status is `!= 'finished'`, so it's a Recheck filter) — index still serves the per-player lookup.

Side note: I had to recreate the `oche-db-1` container (force-recreate, volume preserved) to pick up the `127.0.0.1:5432:5432` port mapping that wasn't bound on the pre-existing container, and I temporarily symlinked `node_modules` from the main repo into the worktree to run `migrate.mjs`. The symlink has been removed; the db container is left running (it was already up before — only the recreation was needed).

## Commits

- `994130b` Merge origin/main into feature branch
- `8421ac1` feat: Add per-player indexes to the games table
- `38bfe41` chore(release): 1.12.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Plan: Add per-player indexes to the games table

## Context

`getMyGames` (`lib/db/games.ts:226-243`) and `getGameHistory` (`lib/db/history.ts:49-62`) both filter games by `(player1_id = $user OR player2_id = $user)` plus a status predicate. The only existing `games` index is `games(status, created_at DESC)` from `002_games.sql:14`, which doesn't help these per-player lookups — Postgres falls back to a sequential scan today. As game volume grows on `oche.cloud`, both the lobby's "Your games" poll (every 5s) and the `/history` page will get slower than they need to.

This migration adds two composite indexes leading with the player id so each side of the `OR` can use a BitmapOr index scan. The `player2_id` index is partial — most games have a `player2_id` (only training/local guest games have `NULL`), so excluding `NULL` rows keeps the index lean without losing any matched rows (the predicate `player2_id = $user` never matches `NULL` anyway).

## Files to change

1. **Create** `lib/db/migrations/006_game_player_indexes.sql` — exactly the SQL from the request:
   ```sql
   CREATE INDEX IF NOT EXISTS games_player1_status_finished_idx ON games(player1_id, status, finished_at DESC);
   CREATE INDEX IF NOT EXISTS games_player2_status_finished_idx ON games(player2_id, status, finished_at DESC) WHERE player2_id IS NOT NULL;
   ```

2. **Update** `CLAUDE.md` (around line 208) — add one line under the migrations folder listing:
   ```
   │           └── 006_game_player_indexes.sql  per-player composite indexes for getMyGames/getGameHistory
   ```
   and shift the box-drawing for `005_profiles.sql` from `└──` to `├──`.

No other code changes — `getMyGames` and `getGameHistory` keep their existing SQL; the planner picks up the new indexes automatically.

## Verification

Run all in the running Docker stack (the app container has `DATABASE_URL` set; running `node scripts/migrate.mjs` directly on the host has no env loaded):

1. **Apply the migration**
   ```bash
   docker compose exec app node scripts/migrate.mjs
   ```
   Expect `→ applying: 006_game_player_indexes.sql` then `✓ applied`.

2. **Idempotency**
   ```bash
   docker compose exec app node scripts/migrate.mjs
   ```
   Expect `✓ already applied: 006_game_player_indexes.sql` for the new file (and the same for 001–005).

3. **EXPLAIN the two target queries** against a real `userId` from the DB:
   ```bash
   docker compose exec db psql -U oche -d oche -c "
     EXPLAIN SELECT g.id, g.status, g.finished_at
     FROM games g
     WHERE (g.player1_id = 1 OR g.player2_id = 1)
       AND g.status = 'finished'
       AND g.match_state IS NOT NULL
     ORDER BY g.finished_at DESC NULLS LAST LIMIT 50;"

   docker compose exec db psql -U oche -d oche -c "
     EXPLAIN SELECT g.id, g.status, g.created_at
     FROM games g
     WHERE g.status != 'finished'
       AND (g.player1_id = 1 OR g.player2_id = 1)
     ORDER BY g.created_at DESC LIMIT 10;"
   ```
   Expect the plan to mention `games_player1_status_finished_idx` and/or `games_player2_status_finished_idx` (typically a `BitmapOr` of two `Bitmap Index Scan` nodes). With only a handful of rows in the local DB the planner may still pick a sequential scan — if so, force it temporarily with `SET LOCAL enable_seqscan = off;` inside a transaction to confirm the indexes *can* be used, then `ROLLBACK`.

   Note: `getMyGames` orders by `created_at DESC`, not `finished_at DESC`, so the index helps the WHERE filter but not the sort. That's expected and fine — the LIMIT 10 over a tiny non-finished set means the sort cost is negligible; the win is avoiding the seq scan on the per-player filter.

4. **No regressions** — `npx tsc --noEmit` and `npm test` should still pass (no code changed, but worth a sanity check on the doc edit).

</details>

## Original Request

**Add per-player indexes to the games table**

> Add a new migration `lib/db/migrations/006_game_player_indexes.sql` containing:
> 
> ```sql
> CREATE INDEX IF NOT EXISTS games_player1_status_finished_idx ON games(player1_id, status, finished_at DESC);
> CREATE INDEX IF NOT EXISTS games_player2_status_finished_idx ON games(player2_id, status, finished_at DESC) WHERE player2_id IS NOT NULL;
> ```
> 
> The partial index on player2 keeps it small (most rows have a player2). Verify with `EXPLAIN` against `getMyGames` and `getGameHistory` queries that the new indexes are used. Update CLAUDE.md's migration list. Run `node scripts/migrate.mjs` locally to confirm it applies cleanly, and that re-running prints `✓ already applied`. No code changes outside the migration file and the docs.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)