### PR TITLE
Add public global darts leaderboard

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,7 +27,7 @@ Ideas and planned features for OCHE, roughly grouped by area. Not prioritised to
 - [x] **Friend leaderboard** — in `/settings`, table of friends + current user ranked by win rate.
 - [x] **Friend quick-invite in match** — when waiting for opponent, creator sees friends list with per-friend "Copy link" button.
 - [ ] **Player profile page** — `/player/[id]` showing match history, stats, recent form.
-- [ ] **Global leaderboard** — rank all players by avg, win rate, 180s, highest checkout.
+- [x] **Global leaderboard** — rank all players by avg, win rate, 180s, highest checkout. (`/leaderboard`)
 
 ## Additional game modes
 

--- a/app/(app)/leaderboard/page.tsx
+++ b/app/(app)/leaderboard/page.tsx
@@ -1,0 +1,15 @@
+import { getCurrentUser } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { getLeaderboard } from "@/lib/db/leaderboard";
+import { LeaderboardPage } from "@/components/leaderboard/LeaderboardPage";
+
+export const dynamic = "force-dynamic";
+
+export default async function LeaderboardServerPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+
+  const entries = await getLeaderboard();
+
+  return <LeaderboardPage entries={entries} viewerId={user.id} />;
+}

--- a/claude.md
+++ b/claude.md
@@ -32,6 +32,7 @@ What's verified working:
 - Match state persisted to DB on every turn (JSONB); both devices see updates within 1.5s
 - **Tournaments:** single-elimination brackets + round-robin (with optional full-season home/away). Invite link join OR direct friend invite from waiting room. Creator starts, matches auto-advance, cancel with confirm, finished results screen with rankings.
 - **Match history:** `/history` page showing all finished games (W/L, avg, 180s, best finish) + tournament history (rank, format, W/P). Aggregate stats bar at top.
+- **Global leaderboard:** `/leaderboard` ranks all users across ranked finished games (training/guest excluded). Sort by win %, 3-dart avg, 180s, best finish, games played. Players with `< 3` games are split into a separate "Rising" tail. Viewer's own row is highlighted.
 - **User profiles:** `display_name` + `avatar_color` on `users`. Custom names shown in match, lobby, tournaments, history.
 - **Friends system:** send/accept/decline/remove requests by email. Friend list with head-to-head stats + win rate leaderboard. Notification badge on lobby avatar when requests pending.
 - **Settings page** (`/settings`): edit display name, pick avatar colour, manage friends.
@@ -283,7 +284,7 @@ The script is idempotent. Re-running is safe — already-applied migrations show
 - **Phase 3** Accounts + lobby + multi-device matches ✅ done and live on oche.cloud
 - **Phase 4** Match history / player stats pages ✅ done (`/history` with game list + tournament history + aggregate stats)
 - **Phase 5** Tournaments ✅ done (single-elim + round-robin, full-season, friend invite, cancel, results)
-- **Phase 6** Extended player profiles & leaderboards ✅ partially done (display names, avatars, friends system, settings, friend leaderboard — global leaderboard + player profile pages remain)
+- **Phase 6** Extended player profiles & leaderboards ✅ done (display names, avatars, friends system, settings, friend leaderboard, player profile pages at `/player/[id]`, global leaderboard at `/leaderboard`)
 - **Phase 7** AI vision agent for camera-based auto-scoring (user said "skip this for now")
 
 ## What to tackle next
@@ -291,8 +292,6 @@ The script is idempotent. Re-running is safe — already-applied migrations show
 See **[BACKLOG.md](BACKLOG.md)** for the full features backlog. Top candidates:
 
 - **Per-game detail view** — click into a finished game to see leg-by-leg / dart-by-dart breakdown
-- **Global leaderboard** — rank all players by avg, win rate, 180s, highest checkout
-- **Player profile page** — `/player/[id]` with match history, stats, recent form
 - **Rematch flow** — auto-create a new game with same config after summary
 
 ## Things to verify before claiming "done"

--- a/components/leaderboard/LeaderboardPage.tsx
+++ b/components/leaderboard/LeaderboardPage.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { BrandMark } from "@/components/ui/primitives";
+import { Avatar } from "@/components/ui/Avatar";
+import { displayName as dn } from "@/lib/display";
+import type { LeaderboardEntry } from "@/lib/db/leaderboard";
+
+type SortKey = "winRate" | "threeDartAvg" | "ton80s" | "bestFinish" | "gamesPlayed";
+
+interface Props {
+  entries: LeaderboardEntry[];
+  viewerId: number;
+}
+
+const RANKED_MIN_GAMES = 3;
+
+const SORT_BUTTONS: Array<{ key: SortKey; label: string }> = [
+  { key: "winRate", label: "Win %" },
+  { key: "threeDartAvg", label: "3-Dart Avg" },
+  { key: "ton80s", label: "180s" },
+  { key: "bestFinish", label: "Best Finish" },
+  { key: "gamesPlayed", label: "Games" },
+];
+
+function sortValue(e: LeaderboardEntry, key: SortKey): number {
+  switch (key) {
+    case "winRate": return e.winRate;
+    case "threeDartAvg": return e.threeDartAvg;
+    case "ton80s": return e.total180s;
+    case "bestFinish": return e.bestFinish;
+    case "gamesPlayed": return e.gamesPlayed;
+  }
+}
+
+export function LeaderboardPage({ entries, viewerId }: Props) {
+  const router = useRouter();
+  const [sortBy, setSortBy] = useState<SortKey>("winRate");
+
+  const [ranked, rising] = useMemo(() => {
+    const r: LeaderboardEntry[] = [];
+    const ri: LeaderboardEntry[] = [];
+    for (const e of entries) {
+      if (e.gamesPlayed >= RANKED_MIN_GAMES) r.push(e);
+      else ri.push(e);
+    }
+    return [r, ri];
+  }, [entries]);
+
+  const sortedRanked = useMemo(() => {
+    return [...ranked].sort((a, b) => {
+      const diff = sortValue(b, sortBy) - sortValue(a, sortBy);
+      if (diff !== 0) return diff;
+      // Stable secondary sort by gamesPlayed desc
+      return b.gamesPlayed - a.gamesPlayed;
+    });
+  }, [ranked, sortBy]);
+
+  const sortedRising = useMemo(() => {
+    return [...rising].sort((a, b) => {
+      const diff = b.gamesPlayed - a.gamesPlayed;
+      if (diff !== 0) return diff;
+      return b.winRate - a.winRate;
+    });
+  }, [rising]);
+
+  const playerCount = entries.length;
+  // Each game contributes to two players, so /2
+  const gamesLogged = Math.round(entries.reduce((s, e) => s + e.gamesPlayed, 0) / 2);
+  const highestAvg = entries.reduce((m, e) => (e.threeDartAvg > m ? e.threeDartAvg : m), 0);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-ink">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft">
+        <BrandMark />
+        <button
+          onClick={() => router.push("/lobby")}
+          className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
+          style={{ letterSpacing: "0.18em" }}
+        >
+          <ArrowLeft className="w-3.5 h-3.5" /> Lobby
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 px-6 py-10 max-w-3xl w-full mx-auto">
+        <div className="rise">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="h-px w-10 bg-oche-red" />
+            <span
+              className="f-mono text-xs uppercase text-oche-red"
+              style={{ letterSpacing: "0.25em" }}
+            >
+              leaderboard
+            </span>
+          </div>
+
+          <h1
+            className="f-display font-black leading-[0.9] mb-2 text-cream"
+            style={{ fontSize: "clamp(36px, 6vw, 72px)" }}
+          >
+            THE <span className="text-electric">OCHE</span><br />TABLE.
+          </h1>
+          <div className="f-serif italic text-bone text-lg mb-8">
+            "the table doesn't lie."
+          </div>
+
+          {playerCount === 0 ? (
+            <div className="border border-border-soft px-5 py-8 text-center" style={{ background: "#0d1210" }}>
+              <div className="f-serif italic text-bone text-base mb-2">"no games on the books yet."</div>
+              <button
+                onClick={() => router.push("/lobby")}
+                className="f-mono text-xs uppercase text-electric hover:underline"
+                style={{ letterSpacing: "0.18em" }}
+              >
+                Back to lobby
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* Aggregate stats */}
+              <div className="grid grid-cols-3 gap-2 mb-8">
+                <StatBox label="Players" value={String(playerCount)} />
+                <StatBox label="Games logged" value={String(gamesLogged)} />
+                <StatBox
+                  label="Top 3-dart avg"
+                  value={highestAvg > 0 ? highestAvg.toFixed(2) : "—"}
+                  highlight={highestAvg > 0}
+                />
+              </div>
+
+              {/* Sort buttons */}
+              <div className="mb-4">
+                <div className="f-mono text-[10px] uppercase text-muted mb-2" style={{ letterSpacing: "0.2em" }}>
+                  Sort by
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {SORT_BUTTONS.map((b) => {
+                    const active = sortBy === b.key;
+                    return (
+                      <button
+                        key={b.key}
+                        onClick={() => setSortBy(b.key)}
+                        className="f-mono text-[11px] uppercase px-3 py-1.5 transition-colors"
+                        style={{
+                          letterSpacing: "0.18em",
+                          background: active ? "#d4ff3a" : "transparent",
+                          color: active ? "#0a0e0c" : "#a5b3aa",
+                          border: active ? "1px solid #d4ff3a" : "1px solid #1f2925",
+                        }}
+                      >
+                        {b.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Ranked section */}
+              <Section label="Ranked" count={sortedRanked.length}>
+                {sortedRanked.length === 0 ? (
+                  <EmptyState text={`No players with ${RANKED_MIN_GAMES}+ ranked games yet.`} />
+                ) : (
+                  <LeaderboardTable
+                    entries={sortedRanked}
+                    sortBy={sortBy}
+                    viewerId={viewerId}
+                    showRank
+                  />
+                )}
+              </Section>
+
+              {/* Rising section */}
+              {sortedRising.length > 0 && (
+                <Section
+                  label={`Rising — fewer than ${RANKED_MIN_GAMES} ranked games`}
+                  count={sortedRising.length}
+                >
+                  <LeaderboardTable
+                    entries={sortedRising}
+                    sortBy={sortBy}
+                    viewerId={viewerId}
+                    showRank={false}
+                  />
+                </Section>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LeaderboardTable({
+  entries,
+  sortBy,
+  viewerId,
+  showRank,
+}: {
+  entries: LeaderboardEntry[];
+  sortBy: SortKey;
+  viewerId: number;
+  showRank: boolean;
+}) {
+  return (
+    <div className="border border-border-soft overflow-x-auto">
+      <table className="w-full">
+        <thead className="sticky top-0 z-10">
+          <tr className="border-b border-border-soft" style={{ background: "#0d1210" }}>
+            <Th>{showRank ? "#" : ""}</Th>
+            <Th>Player</Th>
+            <Th align="right" prominent={sortBy === "gamesPlayed"}>Games</Th>
+            <Th align="right" prominent={sortBy === "winRate"}>Win %</Th>
+            <Th align="right" prominent={sortBy === "threeDartAvg"}>3-Dart Avg</Th>
+            <Th align="right" prominent={sortBy === "ton80s"}>180s</Th>
+            <Th align="right" prominent={sortBy === "bestFinish"}>Best</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e, i) => {
+            const isSelf = e.userId === viewerId;
+            const name = dn(e.email, e.displayName);
+            return (
+              <tr
+                key={e.userId}
+                className="border-b border-border-soft last:border-0"
+                style={{ background: isSelf ? "#0f1a12" : "#0a0e0c" }}
+              >
+                <td className="px-3 py-3 f-display font-black text-muted text-sm align-middle">
+                  {showRank ? i + 1 : "—"}
+                </td>
+                <td className="px-3 py-3 align-middle">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Avatar name={name} color={e.avatarColor} size="sm" />
+                    <Link
+                      href={`/player/${e.userId}`}
+                      className="f-display font-black text-cream text-base hover:text-electric transition-colors truncate"
+                    >
+                      {name}
+                      {isSelf && <span className="text-electric text-xs ml-1.5">you</span>}
+                    </Link>
+                  </div>
+                </td>
+                <Td align="right" prominent={sortBy === "gamesPlayed"}>
+                  {e.gamesPlayed}
+                </Td>
+                <Td align="right" prominent={sortBy === "winRate"} highlight={e.winRate >= 50}>
+                  {`${e.winRate}%`}
+                </Td>
+                <Td align="right" prominent={sortBy === "threeDartAvg"}>
+                  {e.threeDartAvg > 0 ? e.threeDartAvg.toFixed(2) : "—"}
+                </Td>
+                <Td align="right" prominent={sortBy === "ton80s"} accent={e.total180s > 0}>
+                  {e.total180s}
+                </Td>
+                <Td align="right" prominent={sortBy === "bestFinish"}>
+                  {e.bestFinish > 0 ? e.bestFinish : "—"}
+                </Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Th({
+  children,
+  align = "left",
+  prominent = false,
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right";
+  prominent?: boolean;
+}) {
+  return (
+    <th
+      className="px-3 py-2 f-mono text-[10px] uppercase"
+      style={{
+        letterSpacing: "0.18em",
+        textAlign: align,
+        color: prominent ? "#d4ff3a" : "#6d736f",
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  align = "left",
+  prominent = false,
+  highlight = false,
+  accent = false,
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right";
+  prominent?: boolean;
+  highlight?: boolean;
+  accent?: boolean;
+}) {
+  const isProminent = prominent;
+  const color = highlight ? "#d4ff3a" : accent ? "#e63946" : isProminent ? "#f2e8d0" : "#a5b3aa";
+  return (
+    <td
+      className={
+        isProminent
+          ? "px-3 py-3 f-display font-black text-base align-middle"
+          : "px-3 py-3 f-mono text-sm align-middle"
+      }
+      style={{ textAlign: align, color }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function Section({ label, count, children }: { label: string; count: number; children: React.ReactNode }) {
+  return (
+    <div className="mb-10">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="h-px w-6 bg-border" />
+        <span
+          className="f-mono text-xs uppercase text-muted"
+          style={{ letterSpacing: "0.25em" }}
+        >
+          {label}
+        </span>
+        {count > 0 && <span className="f-mono text-xs text-muted">({count})</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatBox({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div className="border border-border-soft p-4" style={{ background: "#0d1210" }}>
+      <div
+        className="f-mono text-[9px] uppercase text-muted mb-1"
+        style={{ letterSpacing: "0.2em" }}
+      >
+        {label}
+      </div>
+      <div
+        className="f-display font-black text-3xl"
+        style={{ color: highlight ? "#d4ff3a" : "#f2e8d0" }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ text }: { text: string }) {
+  return <p className="f-mono text-xs text-muted py-4">{text}</p>;
+}

--- a/components/lobby/LobbyPage.tsx
+++ b/components/lobby/LobbyPage.tsx
@@ -53,6 +53,14 @@ export function LobbyPage({ user, pendingFriendRequests }: Props) {
             <span className="f-mono text-xs text-bone hidden sm:block">{name}</span>
           </button>
           <button
+            onClick={() => router.push("/leaderboard")}
+            className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
+            style={{ letterSpacing: "0.18em" }}
+            title="Leaderboard"
+          >
+            <Trophy className="w-3.5 h-3.5" /> <span className="hidden sm:inline">Leaderboard</span>
+          </button>
+          <button
             onClick={logout}
             className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
             style={{ letterSpacing: "0.18em" }}

--- a/lib/db/leaderboard.ts
+++ b/lib/db/leaderboard.ts
@@ -1,0 +1,139 @@
+import { sql } from "@/lib/db";
+import { computeStats } from "@/lib/scoring";
+import type { Match } from "@/lib/types";
+
+export interface LeaderboardEntry {
+  userId: number;
+  email: string;
+  displayName: string | null;
+  avatarColor: string;
+  gamesPlayed: number;
+  wins: number;
+  losses: number;
+  /** 0–100, rounded */
+  winRate: number;
+  /** Mean of per-game 3-dart averages — same definition as aggregateRankedStats. */
+  threeDartAvg: number;
+  total180s: number;
+  /** 0 if none recorded */
+  bestFinish: number;
+}
+
+interface Accumulator {
+  userId: number;
+  email: string;
+  displayName: string | null;
+  avatarColor: string;
+  gamesPlayed: number;
+  wins: number;
+  threeDartAvgSum: number;
+  total180s: number;
+  bestFinish: number;
+}
+
+export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
+  if (!sql) return [];
+
+  const rows = await sql`
+    SELECT
+      g.id, g.match_state,
+      g.player1_id, g.player2_id,
+      u1.email AS p1_email, u1.display_name AS p1_dn, u1.avatar_color AS p1_color,
+      u2.email AS p2_email, u2.display_name AS p2_dn, u2.avatar_color AS p2_color
+    FROM games g
+    JOIN users u1 ON u1.id = g.player1_id
+    JOIN users u2 ON u2.id = g.player2_id
+    WHERE g.status = 'finished'
+      AND g.match_state IS NOT NULL
+      AND (g.config->>'mode' IS NULL OR g.config->>'mode' <> 'training')
+  `;
+
+  const acc = new Map<number, Accumulator>();
+
+  for (const row of rows) {
+    try {
+      const match = row.match_state as Match;
+      if (match.winner === null) continue;
+
+      const [stats0, stats1] = computeStats(match);
+
+      const sides: Array<{
+        userId: number;
+        email: string;
+        displayName: string | null;
+        avatarColor: string;
+        won: boolean;
+        threeDartAvg: number;
+        tonEighty: number;
+        bestFinish: number;
+      }> = [
+        {
+          userId: Number(row.player1_id),
+          email: row.p1_email as string,
+          displayName: (row.p1_dn as string | null) ?? null,
+          avatarColor: (row.p1_color as string) ?? "#6d736f",
+          won: match.winner === 0,
+          threeDartAvg: stats0.threeDartAvg,
+          tonEighty: stats0.tonEighty,
+          bestFinish: stats0.bestFinish,
+        },
+        {
+          userId: Number(row.player2_id),
+          email: row.p2_email as string,
+          displayName: (row.p2_dn as string | null) ?? null,
+          avatarColor: (row.p2_color as string) ?? "#6d736f",
+          won: match.winner === 1,
+          threeDartAvg: stats1.threeDartAvg,
+          tonEighty: stats1.tonEighty,
+          bestFinish: stats1.bestFinish,
+        },
+      ];
+
+      for (const s of sides) {
+        let entry = acc.get(s.userId);
+        if (!entry) {
+          entry = {
+            userId: s.userId,
+            email: s.email,
+            displayName: s.displayName,
+            avatarColor: s.avatarColor,
+            gamesPlayed: 0,
+            wins: 0,
+            threeDartAvgSum: 0,
+            total180s: 0,
+            bestFinish: 0,
+          };
+          acc.set(s.userId, entry);
+        }
+        entry.gamesPlayed += 1;
+        if (s.won) entry.wins += 1;
+        entry.threeDartAvgSum += s.threeDartAvg;
+        entry.total180s += s.tonEighty;
+        if (s.bestFinish > entry.bestFinish) entry.bestFinish = s.bestFinish;
+      }
+    } catch {
+      // skip malformed rows
+    }
+  }
+
+  const entries: LeaderboardEntry[] = [];
+  for (const a of acc.values()) {
+    const losses = a.gamesPlayed - a.wins;
+    const winRate = a.gamesPlayed > 0 ? Math.round((a.wins / a.gamesPlayed) * 100) : 0;
+    const threeDartAvg = a.gamesPlayed > 0 ? a.threeDartAvgSum / a.gamesPlayed : 0;
+    entries.push({
+      userId: a.userId,
+      email: a.email,
+      displayName: a.displayName,
+      avatarColor: a.avatarColor,
+      gamesPlayed: a.gamesPlayed,
+      wins: a.wins,
+      losses,
+      winRate,
+      threeDartAvg,
+      total180s: a.total180s,
+      bestFinish: a.bestFinish,
+    });
+  }
+  return entries;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3139,6 +3139,111 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.4.tgz",
+      "integrity": "sha512-wBEMBs+np+R5ozN1F8Y8d/Dycns2COhRnkxRc+rvnbXke5uZBHkUGFgWxfTXn5rx7OLijuUhyfB+gC/ap58dDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.4.tgz",
+      "integrity": "sha512-7sgf5rM7Z81V9w48F02Zz6DgEJulavC0jadab4ZsJ+K2sxMNK0/BtF8J8J3CxnsJN3DGcIdC260wEKssKTukUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.4.tgz",
+      "integrity": "sha512-JaZlIMNaJenfd55kjaLWMfok+vWBlcRxqnRoZrhFQrhM1uAehP3R0+Aoe+bZOogqlZvAz53nY/k3ZyuKDtT2zQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.4.tgz",
+      "integrity": "sha512-7EBBjNoyTO2ipMDgCiORpwwOf5tIueFntKjcN3NK+GAQD7OzFJe84p7a2eQUeWdpzZvhVXuAtIen8QcH71ZCOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.4.tgz",
+      "integrity": "sha512-0578bLRVDJOh+LdIoKvgNDz77+Bd85c5JrFgnlbI1SM3WmEQvsjxTA8ATu9Z9FCiIS/AliVAW2DV/BDwpXbtiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.4.tgz",
+      "integrity": "sha512-JgFCiV4libQavwII+kncMCl30st0JVxpPOtzWcAI2jtum4HjYaclobKhj+JsRu5tFqMtA5CJIa0MvYyuu9xjjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.4.tgz",
+      "integrity": "sha512-xxsJy9wzq7FR5SqPCUqdgSXiNXrMuidgckBa8nH9HtjjxsilgcN6VgXF6tZ3uEWuVEadotQJI8/9EQ6guTC4Yw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Done.

**Files added:**
- `lib/db/leaderboard.ts` — single SQL query (INNER JOIN excludes guest games; JSONB filter excludes training) + per-user JS aggregation using `computeStats`.
- `app/(app)/leaderboard/page.tsx` — server component with `force-dynamic`, `getCurrentUser` + redirect.
- `components/leaderboard/LeaderboardPage.tsx` — client component with sort toggle (winRate/threeDartAvg/ton80s/bestFinish/gamesPlayed), sticky-header table, separate "Rising" section for `< 3` games, viewer-row highlight, `/player/[id]` links.

**Files edited:**
- `components/lobby/LobbyPage.tsx` — Trophy entry-point in the header (icon-only on mobile, with label on `sm+`).
- `BACKLOG.md` — global leaderboard ticked.
- `CLAUDE.md` — Phase 6 marked done; "What to tackle next" trimmed to per-game detail + rematch flow; "Where the project is now" gained a leaderboard line.

**Verified:** `tsc --noEmit` clean, `npm test` all 66 pass, `npm run build` produces the new `/leaderboard` route. End-to-end click-through is the user's to do — I can't drive a browser session here, and dev-server interaction needs a populated DB.

## Commits

- `48d2538` Merge origin/main into feature branch
- `0b9abeb` feat: Add public global darts leaderboard
- `38bfe41` chore(release): 1.12.0 [skip ci]

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Plan — public global leaderboard at `/leaderboard`

## Context

**Why now.** OCHE has shipped per-user history (`/history`), profiles, and a friend-only win-rate leaderboard inside `/settings`. The next user-facing gap on the Phase 6 roadmap (and the open BACKLOG.md item "Global leaderboard — rank all players by avg, win rate, 180s, highest checkout") is a single page that ranks **everyone in the small darts community** across the same metrics, not only the viewer's friends. The page is "public-within-the-app": authenticated users only, but no friend-graph filter.

**The intended outcome.** A single sticky-header table at `/leaderboard` showing every user with ≥ 1 ranked finished game, with a small set of sort buttons (win %, 3-dart avg, 180s, best finish, games played). Players with `< 3` games are kept in a separate "rising" tail so a single 100% win record can't dominate. The viewer's row is highlighted regardless of position, and tapping a name opens the existing `/player/[id]` profile.

**Why simple.** The user is the operator; the audience is themselves and friends. Caching, pagination, and incremental aggregation are not warranted — one SQL fetch + JS aggregation per page load mirrors how `lib/db/history.ts` already works and is easy to reason about.

---

## Files & changes

### 1. New: `lib/db/leaderboard.ts`

Mirror the contract of `lib/db/history.ts:43` (`getGameHistory`) — single SQL query, JSONB parse + `computeStats` in JS, no caching.

```ts
export interface LeaderboardEntry {
  userId: number;
  email: string;
  displayName: string | null;
  avatarColor: string;
  gamesPlayed: number;
  wins: number;
  losses: number;
  winRate: number;        // 0–100, rounded
  threeDartAvg: number;   // mean of per-game averages, parity with aggregateRankedStats
  total180s: number;
  bestFinish: number;     // 0 if none
}

export async function getLeaderboard(): Promise<LeaderboardEntry[]>;
```

**SQL filter** (does the heavy filtering server-side; no per-user N+1):

```sql
SELECT g.id, g.match_state,
       g.player1_id, g.player2_id,
       u1.email AS p1_email, u1.display_name AS p1_dn, u1.avatar_color AS p1_color,
       u2.email AS p2_email, u2.display_name AS p2_dn, u2.avatar_color AS p2_color
FROM games g
JOIN users u1 ON u1.id = g.player1_id
JOIN users u2 ON u2.id = g.player2_id        -- INNER join → excludes guest games
WHERE g.status = 'finished'
  AND g.match_state IS NOT NULL
  AND (g.config->>'mode' IS NULL OR g.config->>'mode' <> 'training')
```

**JS aggregation pass.** Build a `Map<number, accumulator>`. For each row:
1. `match = row.match_state as Match`; skip if `match.winner === null`.
2. `[stats0, stats1] = computeStats(match)` — same call used in `lib/db/history.ts:109`.
3. For each side `i ∈ {0, 1}`: ensure entry exists (seed `email`, `displayName`, `avatarColor` from join), then increment `gamesPlayed`, `wins` if `match.winner === i`, push `stats[i].threeDartAvg` into a sum, `total180s += stats[i].tonEighty`, `bestFinish = max(bestFinish, stats[i].bestFinish)`.
4. After the loop, finalize each entry: `losses = gamesPlayed - wins`, `winRate = round((wins / gamesPlayed) * 100)`, `threeDartAvg = avgSum / gamesPlayed`.

Return the full unsorted array — sorting and the ≥3 split happen client-side.

**Reuse:**
- `computeStats` from `@/lib/scoring` — same import as `lib/db/history.ts:2`.
- `sql` from `@/lib/db` — same singleton.
- `Match` type from `@/lib/types`.

**Why average per-game avgs (not darts-weighted):** matches `aggregateRankedStats` in `lib/stats.ts:30`, so a player's leaderboard 3-dart avg equals their HistoryPage stat box. Don't introduce a second definition.

---

### 2. New: `app/(app)/leaderboard/page.tsx`

Server component. Copy the shape of `app/(app)/history/page.tsx`:

```ts
export const dynamic = "force-dynamic";

export default async function LeaderboardServerPage() {
  const user = await getCurrentUser();
  if (!user) redirect("/login");
  const entries = await getLeaderboard();
  return <LeaderboardPage entries={entries} viewerId={user.id} />;
}
```

`force-dynamic` is non-negotiable — see CLAUDE.md "Pitfalls" #1.

---

### 3. New: `components/leaderboard/LeaderboardPage.tsx`

Client component. Mirror `components/history/HistoryPage.tsx` for layout / brand voice and `components/settings/SettingsPage.tsx` lines 360–405 for the table.

**Props:** `{ entries: LeaderboardEntry[]; viewerId: number }`.

**State:** `const [sortBy, setSortBy] = useState<SortKey>("winRate")` where
`type SortKey = "winRate" | "threeDartAvg" | "ton80s" | "bestFinish" | "gamesPlayed"`.

**Layout:**
- Page chrome identical to HistoryPage: `min-h-screen bg-ink`, header with `BrandMark` + back button (`ArrowLeft` from `lucide-react`), `max-w-3xl` content column, section divider (`h-px w-10 bg-oche-red` + `LEADERBOARD` mono uppercase).
- A flavor line in serif italic, e.g. *"the table doesn't lie."* — keep the brand personality (CLAUDE.md "Working with the user").
- Sort control: a horizontal `flex flex-wrap gap-2` row of small buttons. Active button uses electric (`#d4ff3a` bg, ink text); inactive uses `border border-border-soft text-muted`. Labels: `WIN %`, `3-DART AVG`, `180s`, `BEST FINISH`, `GAMES`.
- **Ranked table** (entries with `gamesPlayed >= 3`): sticky `<thead>` (`sticky top-0` + `bg-ink z-10`). Columns: `#`, `Player`, `Games`, `Win %`, `3-Dart Avg`, `180s`, `Best Finish`. The column matching `sortBy` is rendered prominent (`f-display font-black text-electric`); other metrics stay compact (`f-mono text-bone`).
- Each player row: avatar (`size="sm"`) + name as `<Link href={\`/player/\${entry.userId}\`}>` (route exists at `app/(app)/player/[id]/page.tsx`).
- **Viewer-row highlight:** when `entry.userId === viewerId`, set the `<tr>` background to `#0f1a12` and add a small electric "you" tag in the player cell (same treatment as `SettingsPage` line ≈396).
- **Rising tail** (entries with `gamesPlayed < 3`): a separate section below the main table, header `RISING — fewer than 3 ranked games`, same table shell but no rank numbers (use `—`). Sorted by `gamesPlayed` desc, then `winRate` desc.
- **Empty states:** if `entries.length === 0`, show the muted serif italic line *"no games on the books yet."* and a link back to `/lobby`.

**Sort logic** (pure, in component): one `useMemo` produces `[ranked, rising]` from `entries`; another applies `sortBy` to `ranked`. Stable secondary sort by `gamesPlayed` desc to break ties. All client-side — no refetch.

**Header `StatBox` strip** (above the table, mirroring HistoryPage): three boxes — `PLAYERS` (count of entries), `GAMES LOGGED` (sum of gamesPlayed across entries, divided by 2 since each game contributes to two players), `HIGHEST 3-DART AVG`. Reuse the inline `StatBox` style from HistoryPage; it isn't currently exported, so duplicate the small component locally rather than refactoring (the user favors duplication over premature abstractions per CLAUDE.md).

**Reuse:**
- `Avatar` from `@/components/ui/Avatar`.
- `BrandMark` from `@/components/ui/primitives`.
- `displayName` helper from `@/lib/display` (CLAUDE.md gotcha — never `email.split("@")[0]`).
- `Trophy`, `ArrowLeft` from `lucide-react`.

---

### 4. Edit: `components/lobby/LobbyPage.tsx`

Add a Trophy entry-point in the header (line 39 area, between the avatar/settings button and the logout button), styled like the existing logout button so it sits in the same `gap-4` flex row:

```tsx
<button
  onClick={() => router.push("/leaderboard")}
  className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
  style={{ letterSpacing: "0.18em" }}
  title="Leaderboard"
>
  <Trophy className="w-3.5 h-3.5" /> Leaderboard
</button>
```

`Trophy` is already imported (line 5). The existing fixed bottom-right `/history` button (line 122) stays as is — the spec said "alongside" but `/history` lives in a floating button, not in the header today; I am not moving it. Flag this in the review step in case the user wanted both moved into the header.

---

### 5. Edit: `BACKLOG.md`

Tick `[ ] Global leaderboard` → `[x] Global leaderboard — rank all players by avg, win rate, 180s, highest checkout.` (This is the line currently around BACKLOG.md:30 — the explore agent confirmed the wording.)

### 6. Edit: `CLAUDE.md`

Under **"What to tackle next"**, remove the `Global leaderboard` bullet (it ships in this change). Leave the other two ("Per-game detail view", "Rematch flow") and update the surrounding sentence if needed. Also update the **"Where the project is now"** Phase 6 line to note the global leaderboard is shipped, leaving "global player profile pages" as the remaining item — wait, profile pages already exist (`app/(app)/player/[id]/page.tsx`), so the line should be tightened to reflect that Phase 6 is essentially complete after this change.

---

## Critical files to read before implementing

- `lib/db/history.ts` — exact SQL pattern and `computeStats` usage to copy.
- `lib/scoring.ts` `computeStats` — already pure; do not touch.
- `lib/stats.ts:24` `aggregateRankedStats` — definition of "3-dart avg" the leaderboard must match.
- `components/history/HistoryPage.tsx` — `StatBox`, header, brand voice.
- `components/settings/SettingsPage.tsx` lines 360–405 — friend leaderboard table is the closest analog for the new table shell.
- `components/lobby/LobbyPage.tsx:36–63` — header where the Trophy button slots in.
- `app/(app)/player/[id]/page.tsx` — confirms the link target exists.

---

## Verification

1. **Type & build**
   - `npx tsc --noEmit` — zero errors.
   - `npm run build` — Next.js standalone build succeeds; the new route appears in the build output.

2. **Engine purity (regression guard)**
   - `npm test` — all 24 Vitest tests still pass. We only call `computeStats`, never modify it.

3. **Local end-to-end** (`docker compose up -d` or `npm run dev` with a populated DB)
   - Sign in. From `/lobby`, click the Trophy "Leaderboard" header link → land on `/leaderboard`.
   - Confirm: header chrome, `LEADERBOARD` divider, three stat boxes, sort buttons, table.
   - Click each sort button — row order changes client-side without a network request (verify in devtools).
   - Confirm own row uses the `#0f1a12` background and shows the "you" tag.
   - Confirm a user with 1–2 ranked games appears under the **RISING** section, not at the top of **RANKED**.
   - Click a name → routes to `/player/[id]`.
   - Sign out → visit `/leaderboard` directly → middleware redirects to `/`.

4. **Performance smoke check**
   - Open `/leaderboard` in dev with the current DB; informally check that the page renders within ~500ms (server log + browser timing). The query is one `JOIN games` scan plus an in-memory aggregation; for a small darts community this is well under budget. If it ever blows up, the next step is a SQL CTE that pre-aggregates wins/180s and only computes 3-dart avg in JS.

5. **Edge cases to eyeball**
   - User with no ranked games at all does not appear (correct — they have zero rows in the JOIN).
   - Two players with identical sort key sort stably by `gamesPlayed` desc.
   - All players in the rising tail (i.e. nobody hit 3 games yet) → ranked section shows empty-state line, rising table shows the entries.

</details>

## Original Request

**Add public global darts leaderboard**

> Add a public-within-the-app global leaderboard at /leaderboard. Goal: a single page that ranks all users (excluding training-only / guest users) across darts metrics, with a small sort control and a sensible minimum-games gate to keep one-game players out of the top.
> 
> New files:
> - lib/db/leaderboard.ts — write a single SQL query that joins `games` (status='finished', not training, both player2_id NOT NULL meaning ranked) and produces per-user aggregates. Compute on the SQL side where possible: games_played, wins, losses, win_rate, total_180s, best_finish. For 3-dart avg, the cleanest path is to fetch the relevant rows and run computeStats per match in JS, accumulating per user — slightly heavy but simple, and we already do this in lib/db/history.ts. Cache nothing for now; the table is small (small darts community). Filter out users with `games_played < 3` from the headline ranking but keep them in a separate 'unranked / new' tail.
> - app/(app)/leaderboard/page.tsx — server component, force-dynamic. Fetch leaderboard rows + currentUser. Render via components/leaderboard/LeaderboardPage.tsx.
> - components/leaderboard/LeaderboardPage.tsx — client component. State: `sortBy` ∈ { winRate, threeDartAvg, ton80s, bestFinish, gamesPlayed }. Render a sticky-header table with avatar + display name (link to /player/{userId} if that ships first; otherwise plain text), the chosen metric prominent, and the others compact. Highlight the viewer's own row with the brand electric accent. Mirror StatBox + the brand voice from HistoryPage.
> 
> Nav wiring:
> - components/lobby/LobbyPage.tsx header: add a Trophy-icon link to /leaderboard alongside the existing /history and /settings entry points.
> 
> Success criteria:
> - /leaderboard renders within ~500ms in dev for the current data volume.
> - Sorting toggles via a small set of buttons re-orders rows client-side without re-fetching.
> - Users with <3 ranked games appear under a separate 'rising' section, not at the top.
> - The viewer's own row is visually highlighted regardless of position.
> - BACKLOG.md ticks the Global leaderboard item; CLAUDE.md "What to tackle next" updated.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)