### PR TITLE
Add a /api/health endpoint with DB connectivity check for the VPS deploy

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { sql } from "@/lib/db";
+import pkg from "@/package.json";
+
+export const dynamic = "force-dynamic";
+
+const VERSION = pkg.version;
+const DB_TIMEOUT_MS = 2000;
+const NO_STORE = { "Cache-Control": "no-store" };
+
+export async function GET() {
+  try {
+    if (!sql) throw new Error("Database not configured");
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error("DB query timed out after 2s")),
+        DB_TIMEOUT_MS,
+      );
+    });
+
+    try {
+      await Promise.race([sql`SELECT 1 as ok`, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    return NextResponse.json(
+      { status: "ok", version: VERSION, db: "up", uptime: process.uptime() },
+      { headers: NO_STORE },
+    );
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    const safe = raw.slice(0, 200);
+    return NextResponse.json(
+      { status: "degraded", version: VERSION, db: "down", error: safe },
+      { status: 503, headers: NO_STORE },
+    );
+  }
+}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -20,6 +20,14 @@
 	# Forward everything to the Next.js app
 	reverse_proxy app:3000 {
 		header_up X-Real-IP {remote_host}
+
+		# Optional: enable Caddy active health checks against the app.
+		# The app exposes /api/health → 200 healthy, 503 degraded (DB down).
+		# Uncomment to use:
+		#   health_uri      /api/health
+		#   health_interval 30s
+		#   health_timeout  3s
+		#   health_status   200
 	}
 
 	# Basic security headers

--- a/claude.md
+++ b/claude.md
@@ -314,6 +314,15 @@ docker compose up -d --build app
 docker compose exec app node scripts/migrate.mjs
 ```
 
+After deploy — health smoke test:
+
+```bash
+curl -fsS http://localhost:3000/api/health   # local
+curl -fsS https://oche.cloud/api/health      # production
+# → 200 { "status": "ok", "version": "...", "db": "up", "uptime": ... }
+# → 503 { "status": "degraded", "db": "down", ... } if DB is unreachable
+```
+
 ## Working with the user
 
 - They appreciate clean, terse responses with reasoning shown briefly. Don't over-explain.


### PR DESCRIPTION
## Summary

Build succeeds, `/api/health` is registered as a dynamic (ƒ) route. Type-check clean, no new dependencies added.

Summary of changes:
- `app/api/health/route.ts:1` — new route with 2s `Promise.race` timeout, 200/503 JSON, `Cache-Control: no-store`, error message capped at 200 chars.
- `caddy/Caddyfile:21` — commented-out `health_uri` example inside the `reverse_proxy` block, no live behaviour change.
- `CLAUDE.md:316` — appended a "After deploy — health smoke test" subsection with `curl` lines for local and `oche.cloud`.

To smoke-test live: `docker compose up -d && curl -i http://localhost:3000/api/health`, then `docker compose stop db` and `time curl -i http://localhost:3000/api/health` to confirm 503 within ~2s.

## Commits

- `fb326a2` feat: Add a /api/health endpoint with DB connectivity check for the VPS deploy

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Plan: Lightweight `/api/health` endpoint

## Context

External uptime monitors (and Caddy active health-checks) currently have no cheap, unauthenticated probe against OCHE. We need a liveness endpoint that:

- Is reachable without a session cookie (monitors, Caddy)
- Confirms the Next.js app is up **and** can talk to Postgres
- Fails fast (≤ ~2 s) when the DB is unreachable so monitors don't hang
- Leaks nothing sensitive (no env, no stack traces, no DSN)
- Adds zero new dependencies and stays out of metric-creep territory

## Approach

Create one new route file. No new modules, no new deps. Reuse the existing `sql` singleton from `lib/db/index.ts`. Use `Promise.race` for the 2 s timeout (porsager/postgres has no per-query timeout option for tagged-template queries, and `Promise.race` is the standard pattern; the dangling query is trivial — just `SELECT 1`).

## Files to change

### 1. `app/api/health/route.ts` (NEW)

```ts
import { NextResponse } from "next/server";
import { sql } from "@/lib/db";
import pkg from "@/package.json";

export const dynamic = "force-dynamic";

const VERSION = pkg.version;
const DB_TIMEOUT_MS = 2000;
const NO_STORE = { "Cache-Control": "no-store" };

export async function GET() {
  try {
    if (!sql) throw new Error("Database not configured");

    let timer: ReturnType<typeof setTimeout> | undefined;
    const timeout = new Promise<never>((_, reject) => {
      timer = setTimeout(
        () => reject(new Error("DB query timed out after 2s")),
        DB_TIMEOUT_MS,
      );
    });

    try {
      await Promise.race([sql`SELECT 1 as ok`, timeout]);
    } finally {
      if (timer) clearTimeout(timer);
    }

    return NextResponse.json(
      { status: "ok", version: VERSION, db: "up", uptime: process.uptime() },
      { headers: NO_STORE },
    );
  } catch (err) {
    const raw = err instanceof Error ? err.message : String(err);
    const safe = raw.slice(0, 200);
    return NextResponse.json(
      { status: "degraded", version: VERSION, db: "down", error: safe },
      { status: 503, headers: NO_STORE },
    );
  }
}
```

Notes:
- `pkg from "@/package.json"` works: tsconfig already has `resolveJsonModule: true` and the `@/*` path alias maps to project root. Next.js inlines the JSON at build time, so it's safe under `output: "standalone"`.
- `export const dynamic = "force-dynamic"` prevents Next 15 from statically rendering a stale snapshot at build time (same pitfall noted in CLAUDE.md gotcha #1).
- Error message is capped at 200 chars and is the *message only* — no stack, no DSN, no env. Postgres driver errors like `"ECONNREFUSED"` or `"timed out"` are safe to expose; they don't include credentials.
- No `console.log` of the error — it would hit logs and the user did not request observability here.

### 2. `caddy/Caddyfile` (DOCS ONLY — no live behaviour change)

Add a commented-out example above the `reverse_proxy` block showing how an operator can opt into active health checks:

```
		# Optional: enable Caddy active health checks against the app
		# (uncomment to use; the app exposes /api/health → 200 healthy, 503 degraded)
		#   health_uri      /api/health
		#   health_interval 30s
		#   health_timeout  3s
		#   health_status   200
```

Placed inside the existing `reverse_proxy app:3000 { ... }` block, after `header_up`. All lines commented — zero runtime change.

### 3. `CLAUDE.md` — "Things to verify before claiming done"

Append a third subsection under that heading:

```markdown
When adding/changing API routes:

```bash
curl -fsS http://localhost:3000/api/health | jq .   # local smoke
curl -fsS https://oche.cloud/api/health   | jq .    # post-deploy smoke
```
```

(Keeps existing two subsections intact; just appends.)

## Critical files

- `app/api/health/route.ts` — new
- `caddy/Caddyfile` — comment-only edit, lines ~21–23
- `CLAUDE.md` — append to "Things to verify before claiming done" section (~line 300)

## Reused

- `sql` from `lib/db/index.ts:11` — the existing singleton, no new connection pool
- `NextResponse.json` — same pattern as every other route handler
- `package.json` version field, already at `1.15.0`

## Verification

1. **Happy path:**
   ```bash
   docker compose up -d
   curl -i http://localhost:3000/api/health
   # → HTTP 200, Cache-Control: no-store
   # → {"status":"ok","version":"1.15.0","db":"up","uptime":<seconds>}
   ```

2. **DB down (timeout / connection refused):**
   ```bash
   docker compose stop db
   time curl -i http://localhost:3000/api/health
   # → HTTP 503 within ≤ ~2.5 s
   # → {"status":"degraded","version":"1.15.0","db":"down","error":"..."}
   docker compose start db
   ```

3. **Type & build:**
   ```bash
   npx tsc --noEmit   # zero errors
   npm run build      # next build succeeds
   ```

4. **Leak check:** Confirm the 503 body contains no `DATABASE_URL`, no hostname, no stack frame — only the short message string.

5. **Caddyfile sanity:**
   ```bash
   docker compose exec caddy caddy validate --config /etc/caddy/Caddyfile
   # → no errors (comments are inert)
   ```

</details>

## Original Request

**Add a /api/health endpoint with DB connectivity check for the VPS deploy**

> Add a lightweight health-check endpoint suitable for external uptime monitoring.
> 
> Create `app/api/health/route.ts`:
> 
> - `export const dynamic = 'force-dynamic'` (must not be statically cached).
> - `GET` handler that:
>   - Reads `package.json` version at module load (or imports it).
>   - Runs `sql\`SELECT 1 as ok\`` with a 2-second timeout. Wrap in try/catch.
>   - Returns 200 JSON `{ status: 'ok', version, db: 'up', uptime: process.uptime() }` on success.
>   - Returns 503 JSON `{ status: 'degraded', version, db: 'down', error: <message> }` on DB failure.
> - Set `Cache-Control: no-store` on both responses.
> - No authentication — this needs to be hit by external monitors and Caddy. It MUST NOT leak anything sensitive: do not include env vars, DATABASE_URL, hostnames, or stack traces. Only return the error message string (capped at 200 chars).
> 
> Do NOT make it count users, games, etc — keep it under 20ms in the happy path. The point is liveness, not metrics.
> 
> Update `caddy/Caddyfile` to add a comment showing how an operator can wire this to Caddy's `health_uri` directive (don't change live behavior — just document).
> 
> Update the 'Things to verify before claiming done' section of `CLAUDE.md` to mention `curl https://oche.cloud/api/health` as a smoke test after deploy.
> 
> Acceptance:
> - `curl localhost:3000/api/health` returns 200 with valid JSON when the DB is up.
> - Stopping the postgres container makes it return 503 within ~2 seconds (not hang).
> - `npx tsc --noEmit` clean, `next build` clean, no new dependencies.

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)