### PR TITLE
Allow custom tournament player counts up to sixteen

### DIFF
--- a/components/tournament/CreateTournamentForm.tsx
+++ b/components/tournament/CreateTournamentForm.tsx
@@ -2,9 +2,12 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowRight, X } from "lucide-react";
+import { ArrowRight, Minus, Plus, X } from "lucide-react";
 import type { GameConfig, GameMode, InRule, OutRule } from "@/lib/types";
 import { Label } from "@/components/ui/primitives";
+
+const MIN_PLAYERS = 2;
+const MAX_PLAYERS = 16;
 
 interface Props {
   onClose: () => void;
@@ -132,17 +135,7 @@ export function CreateTournamentForm({ onClose }: Props) {
           {/* Max players */}
           <div>
             <Label>Max players</Label>
-            <div className="grid grid-cols-5 gap-2">
-              {[4, 6, 8, 12, 16].map((n) => (
-                <OptionButton
-                  key={n}
-                  active={maxPlayers === n}
-                  onClick={() => setMaxPlayers(n)}
-                >
-                  <div className="f-display font-black text-2xl">{n}</div>
-                </OptionButton>
-              ))}
-            </div>
+            <PlayerStepper value={maxPlayers} onChange={setMaxPlayers} />
           </div>
 
           {/* Divider */}
@@ -236,6 +229,57 @@ export function CreateTournamentForm({ onClose }: Props) {
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function PlayerStepper({ value, onChange }: { value: number; onChange: (n: number) => void }) {
+  const canDec = value > MIN_PLAYERS;
+  const canInc = value < MAX_PLAYERS;
+  return (
+    <div
+      className="grid grid-cols-[auto_1fr_auto] items-stretch border"
+      style={{ borderColor: "#2a332d", background: "#141a17" }}
+    >
+      <button
+        type="button"
+        aria-label="Decrease max players"
+        onClick={() => canDec && onChange(Math.max(MIN_PLAYERS, value - 1))}
+        disabled={!canDec}
+        className="px-5 flex items-center justify-center border-r"
+        style={{
+          borderColor: "#2a332d",
+          color: canDec ? "#f2e8d0" : "#454b47",
+          cursor: canDec ? "pointer" : "not-allowed",
+        }}
+      >
+        <Minus className="w-5 h-5" strokeWidth={3} />
+      </button>
+      <div className="flex flex-col items-center justify-center py-2">
+        <div className="f-display font-black text-3xl leading-none" style={{ color: "#d4ff3a" }}>
+          {value}
+        </div>
+        <div
+          className="f-mono text-[9px] uppercase text-muted mt-1"
+          style={{ letterSpacing: "0.2em" }}
+        >
+          {value === 1 ? "player" : "players"}
+        </div>
+      </div>
+      <button
+        type="button"
+        aria-label="Increase max players"
+        onClick={() => canInc && onChange(Math.min(MAX_PLAYERS, value + 1))}
+        disabled={!canInc}
+        className="px-5 flex items-center justify-center border-l"
+        style={{
+          borderColor: "#2a332d",
+          color: canInc ? "#f2e8d0" : "#454b47",
+          cursor: canInc ? "pointer" : "not-allowed",
+        }}
+      >
+        <Plus className="w-5 h-5" strokeWidth={3} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The diff is clean. The worktree has no `node_modules`, so I can't run `tsc` or `vitest` locally here — but the change is type-safe (uses only existing patterns and props) and isolated to the form. The plan's verification steps (typecheck, tests, manual browser flow with 5/7/13 players) should be run in your main checkout where dependencies are installed.

Summary:
- `components/tournament/CreateTournamentForm.tsx`: replaced the fixed `[4, 6, 8, 12, 16]` grid with a `−` / readout / `+` stepper bounded at `MIN_PLAYERS=2` / `MAX_PLAYERS=16`, matching the form's brand styling (cream text on `#141a17`, electric-green readout, disabled state at the bounds).
- No other files touched — the bracket generator, byes auto-advance, API clamp, and DB schema already supported arbitrary counts.

## Changes

**1 files changed (+56 / -12)**

- `components/tournament/CreateTournamentForm.tsx` (+56 / -12)

## Commits

- `5806715` feat: Allow custom tournament player counts up to sixteen

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Allow custom tournament player counts (2–16)

## Context

When creating a tournament, the player count is restricted to a fixed set of buttons: 4, 6, 8, 12, 16. The user can't pick 5, 7, 13, etc. — which feels arbitrary, especially for casual friend tournaments where you bring whoever shows up.

**Is there a reason for the whitelist?** No — it's purely a UI choice in `CreateTournamentForm.tsx`. The rest of the stack already supports arbitrary counts:

- **Bracket generator (`lib/tournament.ts:117-160`)** rounds up to the next power of 2 via `nextPow2()` and creates `status: "bye"` matches for the missing seeds. Byes are auto-advanced in `lib/db/tournaments.ts:233-249` (`SET winner_id = ..., status = 'bye'`, then `getAdvancementSlot` feeds them into round 2). The "is tournament over" check at `lib/db/tournaments.ts:484` already excludes byes (`status NOT IN ('finished', 'bye')`).
- **Round-robin generator (`lib/tournament.ts:88-114`)** pairs every player with every other player — works for any N ≥ 2, and `seasonHalves=2` just reverses the home/away ordering.
- **`TournamentBracket.tsx:121-162`** is fully format-agnostic: it groups whatever matches exist by `round` and sorts by `matchNumber`. No power-of-2 assumption.
- **API (`app/api/tournaments/route.ts:38`)** already clamps with `Math.min(16, Math.max(2, maxPlayers))`.
- **DB schema (`003_tournaments.sql:8`)** is `max_players INT NOT NULL DEFAULT 8` — no CHECK constraint. Comment says "2-16" but it's never enforced.

So this is a **one-file UI change**. The whole stack is already ready.

## Approach

Replace the 5-button fixed grid in `CreateTournamentForm.tsx` with a stepper (− / readout / +) that lets the user pick any value from 2 to 16, defaulting to 8. The stepper preserves the form's brand aesthetic (electric-green readout, `f-display font-black`, dark borders) and matches the visual weight of the surrounding rows so the form layout doesn't shift. No API, DB, bracket-logic, or rendering changes.

## Files

- EDIT `components/tournament/CreateTournamentForm.tsx` — replace the Max Players button grid (lines 132–146) with a stepper. Add `MIN_PLAYERS = 2` and `MAX_PLAYERS = 16` constants at module top so the bounds are explicit and match the API clamp.

## Steps

1. In `components/tournament/CreateTournamentForm.tsx`, add module-level constants `const MIN_PLAYERS = 2; const MAX_PLAYERS = 16;` near the top of the file (just below imports).
2. Replace the Max Players block (lines 132–146) with a stepper:
   - `−` button (disabled when `maxPlayers <= MIN_PLAYERS`) calls `setMaxPlayers((n) => Math.max(MIN_PLAYERS, n - 1))`.
   - Centered readout: number in `f-display font-black text-3xl` (electric green `#d4ff3a`), with a small `f-mono` "players" caption underneath using the existing muted style.
   - `+` button (disabled when `maxPlayers >= MAX_PLAYERS`) calls `setMaxPlayers((n) => Math.min(MAX_PLAYERS, n + 1))`.
   - Wrap in the same border treatment used by `OptionButton` so it sits flush with the other form rows. Layout suggestion: a single bordered row using `grid grid-cols-[auto_1fr_auto]` with the buttons sized similarly to `OptionButton` (≈48–56px square) and the readout filling the middle.
   - Buttons use `aria-label="Decrease max players"` / `aria-label="Increase max players"` for accessibility. Use `<button type="button">` so they don't submit the form.
3. Keep the existing `useState(8)` default — current users see the same starting value.
4. Leave the request body shape unchanged (`maxPlayers` is already sent as a number); the API clamp at `app/api/tournaments/route.ts:38` is a safety net.

## What stays exactly as-is

- `lib/tournament.ts` — bye padding already handles 3, 5, 6, 7, 9, 10, 11, 13, 14, 15.
- `lib/db/tournaments.ts` — bye auto-advance and the all-matches-finished check.
- `TournamentBracket.tsx` / `TournamentStandings.tsx` — render whatever matches the generator produces.
- `app/api/tournaments/route.ts` — `Math.min(16, Math.max(2, maxPlayers))` clamp.
- DB schema and migrations — no new migration.

## Verification

1. `npx tsc --noEmit` — should report zero errors.
2. `npm test` — all 24 scoring tests should still pass (untouched, but confirm no regressions).
3. Manual flow in browser:
   - Open lobby → "Create tournament" modal.
   - Confirm stepper renders, starts at 8, can be decremented to 2 and incremented to 16, with disabled states at the bounds.
   - Pick **7 players** + Single Elim + 2 invited friends; start the tournament with only 3 players joined. Confirm the bracket renders with the correct byes in round 1, and that bye matches auto-advance their player into round 2.
   - Pick **5 players** + Round Robin (single half), join 3 players, start. Confirm round-robin standings render all C(3,2)=3 matches and no errors.
   - Pick **13 players** + Single Elim, start with 4 players. Confirm 16-slot bracket renders (4 round-1 matches with players, 4 bye matches) and the tournament progresses correctly.
4. Spot-check that existing tournaments (created with 4/6/8/12/16) still display correctly — no migration means stored values are unchanged.

</details>

## Original Request

**Allow custom tournament player counts up to sixteen**

> When I create a new tournament player can be set to 4,6,8,12,16 but that means 5 or 7 would not be possible. That does not make sense to me. Ist there a specific reason?
> 
> Can we make the player freely configurable to a max player number of 16?

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)