### PR TITLE
Prevent accidental logout clicks on mobile

### DIFF
--- a/components/lobby/LobbyPage.tsx
+++ b/components/lobby/LobbyPage.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, LogOut, Trophy, Clock, Target } from "lucide-react";
+import { Plus, Trophy, Clock, Target } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
 import { CreateGameForm } from "./CreateGameForm";
@@ -23,11 +23,6 @@ export function LobbyPage({ user, pendingFriendRequests }: Props) {
   const [showCreate, setShowCreate] = useState(false);
   const [showCreateTournament, setShowCreateTournament] = useState(false);
   const [showCreateTraining, setShowCreateTraining] = useState(false);
-
-  const logout = async () => {
-    await fetch("/api/auth/logout", { method: "POST" });
-    router.push("/");
-  };
 
   const name = dn(user.email, user.displayName);
 
@@ -59,13 +54,6 @@ export function LobbyPage({ user, pendingFriendRequests }: Props) {
             title="Leaderboard"
           >
             <Trophy className="w-3.5 h-3.5" /> <span className="hidden sm:inline">Leaderboard</span>
-          </button>
-          <button
-            onClick={logout}
-            className="flex items-center gap-1.5 f-mono text-xs uppercase text-muted hover:text-cream"
-            style={{ letterSpacing: "0.18em" }}
-          >
-            <LogOut className="w-3.5 h-3.5" /> Logout
           </button>
         </div>
       </div>

--- a/components/settings/SettingsPage.tsx
+++ b/components/settings/SettingsPage.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, UserPlus, Check, X, Trash2 } from "lucide-react";
+import { ArrowLeft, UserPlus, Check, X, Trash2, LogOut } from "lucide-react";
 import { BrandMark } from "@/components/ui/primitives";
 import { Avatar } from "@/components/ui/Avatar";
 import type { User, FriendEntry } from "@/lib/types";
@@ -111,6 +111,11 @@ export function SettingsPage({ user, friends: initialFriends, requests: initialR
   async function cancelRequest(requestId: number) {
     await fetch(`/api/friends/${requestId}`, { method: "DELETE" });
     await refreshFriends();
+  }
+
+  async function logout() {
+    await fetch("/api/auth/logout", { method: "POST" });
+    router.push("/");
   }
 
   // Leaderboard: accepted friends + self
@@ -401,6 +406,17 @@ export function SettingsPage({ user, friends: initialFriends, requests: initialR
               </div>
             </Section>
           )}
+
+          {/* ── Account ── */}
+          <Section label="Account">
+            <button
+              onClick={logout}
+              className="flex items-center gap-2 f-mono text-xs uppercase border border-border-soft text-muted hover:text-oche-red hover:border-oche-red px-5 py-3 transition-colors"
+              style={{ letterSpacing: "0.18em" }}
+            >
+              <LogOut className="w-4 h-4" /> Log out
+            </button>
+          </Section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

All 75 tests pass and `tsc --noEmit` is clean.

**Done.** Logout button removed from the lobby header (only Avatar→Settings and Trophy→Leaderboard remain). New "Account" section at the bottom of `/settings` holds the Logout button, styled as a muted bordered secondary action that turns red on hover so it reads as destructive without competing with the green Save button. The avatar in the lobby header still goes to Settings, so logout is one extra tap away — and well out of the accidental-tap zone on mobile.

## Changes

**2 files changed (+18 / -14)**

- `components/lobby/LobbyPage.tsx` (+1 / -13)
- `components/settings/SettingsPage.tsx` (+17 / -1)

## Commits

- `301e2c0` feat: Prevent accidental logout clicks on mobile

## Implementation Plan

<details>
<summary>Click to expand the plan that was approved</summary>

# Prevent accidental logout taps on mobile

## Context

On the lobby header, three tap targets sit immediately next to each other in the top-right corner: the avatar (→ Settings), the trophy icon (→ Leaderboard), and the Logout button. The Leaderboard label is hidden on mobile (`hidden sm:inline`), but the **"Logout"** text stays visible at all widths, so it becomes the most prominent tap target on a phone — directly adjacent to the avatar a user reaches for to open Settings. A mistapped logout drops the user back to the landing page and forces a fresh magic-link round trip.

Fix: move Logout off the lobby header entirely and into the Settings page (which currently has no logout — surprisingly, since Settings is the conventional home for it). Settings is one tap away via the avatar that's already there, so discoverability is preserved and the accident class is eliminated.

This matches the user's chosen approach ("Move to Settings") from the planning clarification.

## Approach

1. **Remove** the Logout button, its `logout()` handler, and the now-unused `LogOut` import from `components/lobby/LobbyPage.tsx`.
2. **Add** a new "Account" `<Section>` at the bottom of `components/settings/SettingsPage.tsx` containing a single Logout button. Reuse the exact same handler logic (`POST /api/auth/logout` → `router.push("/")`).
3. Style the Settings logout button as a destructive/secondary action — bordered, muted text, with the lucide `LogOut` icon — so it doesn't compete with the primary Save button on the page.

No API changes, no schema changes, no new dependencies. The `/api/auth/logout` route already exists and works.

## Files

- EDIT `components/lobby/LobbyPage.tsx` — remove logout button (lines 63-69), `logout` async function (lines 27-30), and `LogOut` from the lucide-react import (line 5).
- EDIT `components/settings/SettingsPage.tsx` — add `LogOut` to the lucide-react import (line 6); add a new `<Section label="Account">` after the existing Friend leaderboard section (after line 403) containing the Logout button wired to `POST /api/auth/logout` + `router.push("/")`.

## Steps

1. In `components/lobby/LobbyPage.tsx`:
   - Drop `LogOut` from the `lucide-react` import on line 5.
   - Delete the `logout` async function (lines 27-30).
   - Delete the `<button onClick={logout}>…Logout</button>` block (lines 63-69).
   - Leave Avatar (Settings) and Trophy (Leaderboard) buttons untouched — they remain the two header actions.
2. In `components/settings/SettingsPage.tsx`:
   - Add `LogOut` to the existing `lucide-react` import on line 6.
   - Add a local `async function logout()` that calls `await fetch("/api/auth/logout", { method: "POST" })` then `router.push("/")` — same pattern that currently lives in `LobbyPage.tsx`.
   - Append a new `<Section label="Account">` after the Friend leaderboard `<Section>` (after line 403) containing one button styled with `border border-border-soft text-muted hover:text-oche-red`, an inline `<LogOut className="w-4 h-4" />`, and the label `Log out`. Make it un-skinny on mobile (`px-5 py-3`) so it's comfortable to tap intentionally but visually clearly secondary to the green "Save" button above.
3. Sanity-check that no other component imports `logout` from `LobbyPage` (it's a local function, so no external imports — confirmed by reading the file).

## Verification

- `npx tsc --noEmit` — zero errors (only changes are removing one import + handler in one file, adding one import + handler + JSX block in another).
- `npm run build` — succeeds.
- Manual, in a narrow mobile viewport (e.g. 375px) via `npm run dev`:
  1. Log in, land on `/lobby`. Header right-side should show **only** the avatar and the trophy icon — no "LOGOUT" text/button.
  2. Tap the avatar — navigates to `/settings`.
  3. Scroll to the bottom of `/settings` — see new "ACCOUNT" section with "Log out" button.
  4. Tap Log out — redirects to `/` (landing page); reloading any app route should redirect to `/` (session cleared).
- No need to retest the scoring engine — engine code untouched.

</details>

## Original Request

**Prevent accidental logout clicks on mobile**

> Logout button is to close to the leader board and user settings. A user could accidentally hit logout when he is on small mobile dvice

---

🤖 Auto-generated by [Claude Board](https://github.com/anthropics/claude-code)